### PR TITLE
Make only Max the maintainer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,8 @@ Authors@R: c(
            email = "max@rstudio.com", role = c("aut", "cre"), 
            comment = c(ORCID = "0000-0003-2402-136X")),
     person(given = "Alison", family = "Hill", 
-           email = "alison@rstudio.com", role = c("aut", "cre")),           
-    person(given = "Julia", family = "Silge", role = c("aut", "cre"), 
+           email = "alison@rstudio.com", role = c("aut")),           
+    person(given = "Julia", family = "Silge", role = c("aut"), 
            email = "julia.silge@rstudio.com", 
            comment = c(ORCID = "0000-0002-3671-836X")),
     person("RStudio", role = "cph"))


### PR DESCRIPTION
Having three maintainers here broke the tidyverse dashboard, which assumes all packages have 1 maintainer (as CRAN insists).