### PR TITLE
Fixed geom_bar

### DIFF
--- a/content/learn/statistics/xtabs/index.Rmarkdown
+++ b/content/learn/statistics/xtabs/index.Rmarkdown
@@ -45,11 +45,11 @@ To carry out a chi-squared test of independence, we'll examine the association b
 ```{r plot-indep, echo = FALSE}
 ad_data %>%
   ggplot() +
-  aes(y = Genotype, fill = Class) +
+  aes(x = Genotype, fill = Class) +
   geom_bar(position = "fill") +
   scale_fill_brewer(type = "qual") +
-  labs(y = "Genotype: Apolipoprotein E Genetics",
-       x = "Proportion") 
+  labs(x = "Genotype: Apolipoprotein E Genetics",
+       y = "Proportion") 
 ```
 
 If there were no relationship, we would expect to see the purple bars reaching to the same length, regardless of cognitive ability. Are the differences we see here, though, just due to random noise?


### PR DESCRIPTION
In "Statistical analysis of contingency tables" RMarkdown file. Now outputs this:
![Rplot](https://user-images.githubusercontent.com/4574203/79048969-c1ad1480-7bee-11ea-8c0b-b4062cc95e61.png)
