### PR TITLE
Edit the "Resources" stickies

### DIFF
--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -1,10 +1,17 @@
 resources:
+- url: /find/
+  title: Find
+  icon: fa-search
+  icon_pack: fas
+  what: |
+    Explore searchable tables of all tidymodels packages and functions.
+
 - url: /books/
   title: Books
   icon: fa-book-open
   icon_pack: fas
   what: |
-    Study up on predictive modeling with our in-depth books.
+    Study up on statistics and modeling with our comprehensive books.
 
 - url: https://www.tidyverse.org/tags/tidymodels/
   title: News


### PR DESCRIPTION
This PR slightly tweaks the "Books" 📖  sticky and adds the other one we talked about to surface the `/find` resource one more place for folks. Addresses #83.