### PR TITLE
disable highlightjs, Hugo has pygments

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -21,6 +21,7 @@ highlightjsVersion = "9.11.0"
 highlightjsCDN = "//cdn.bootcss.com"
 highlightjsLang = ["r", "yaml"]
 highlightjsTheme = "github"
+disable_highlight = "yes"
 
 MathJaxCDN = "//cdn.bootcss.com"
 MathJaxVersion = "2.7.1"


### PR DESCRIPTION
This was triggering highlightjs to load separately, creating an odd mash-up of syntax highlighting styles and loading color shifts.