### PR TITLE
use metric_set for both models

### DIFF
--- a/content/start/case-study/figs/logistic-results-1.svg
+++ b/content/start/case-study/figs/logistic-results-1.svg
@@ -148,7 +148,7 @@
   <path d="M 35.707031 5.480469 L 426.519531 5.480469 L 426.519531 274.257812 L 35.707031 274.257812 Z M 35.707031 5.480469 "/>
 </clipPath>
 </defs>
-<g id="surface69">
+<g id="surface74">
 <rect x="0" y="0" width="432" height="306" style="fill:rgb(100%,100%,100%);fill-opacity:1;stroke:none;"/>
 <path style="fill:none;stroke-width:1.066978;stroke-linecap:round;stroke-linejoin:round;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:10;" d="M 0 306 L 432 306 L 432 0 L 0 0 Z M 0 306 "/>
 <g clip-path="url(#clip1)" clip-rule="nonzero">

--- a/content/start/case-study/figs/logistic-roc-curve-1.svg
+++ b/content/start/case-study/figs/logistic-roc-curve-1.svg
@@ -148,7 +148,7 @@
   <path d="M 108.171875 5.480469 L 430.949219 5.480469 L 430.949219 328.257812 L 108.171875 328.257812 Z M 108.171875 5.480469 "/>
 </clipPath>
 </defs>
-<g id="surface104">
+<g id="surface109">
 <g clip-path="url(#clip1)" clip-rule="nonzero">
 <path style="fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;stroke-width:1.066978;stroke-linecap:round;stroke-linejoin:round;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:10;" d="M 67.570312 360 L 436.425781 360 L 436.425781 0 L 67.570312 0 Z M 67.570312 360 "/>
 </g>

--- a/content/start/case-study/figs/lr-plot-lines-1.svg
+++ b/content/start/case-study/figs/lr-plot-lines-1.svg
@@ -154,7 +154,7 @@
   <path d="M 35.707031 5.480469 L 426.519531 5.480469 L 426.519531 274.257812 L 35.707031 274.257812 Z M 35.707031 5.480469 "/>
 </clipPath>
 </defs>
-<g id="surface89">
+<g id="surface94">
 <rect x="0" y="0" width="432" height="306" style="fill:rgb(100%,100%,100%);fill-opacity:1;stroke:none;"/>
 <path style="fill:none;stroke-width:1.066978;stroke-linecap:round;stroke-linejoin:round;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:10;" d="M 0 306 L 432 306 L 432 0 L 0 0 Z M 0 306 "/>
 <g clip-path="url(#clip1)" clip-rule="nonzero">

--- a/content/start/case-study/figs/rf-importance-1.svg
+++ b/content/start/case-study/figs/rf-importance-1.svg
@@ -220,7 +220,7 @@
   <path d="M 154.0625 5.480469 L 498.519531 5.480469 L 498.519531 328.257812 L 154.0625 328.257812 Z M 154.0625 5.480469 "/>
 </clipPath>
 </defs>
-<g id="surface184">
+<g id="surface194">
 <rect x="0" y="0" width="504" height="360" style="fill:rgb(100%,100%,100%);fill-opacity:1;stroke:none;"/>
 <path style="fill:none;stroke-width:1.066978;stroke-linecap:round;stroke-linejoin:round;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:10;" d="M 0 360 L 504 360 L 504 0 L 0 0 Z M 0 360 "/>
 <g clip-path="url(#clip1)" clip-rule="nonzero">

--- a/content/start/case-study/figs/rf-lr-roc-curve-1.svg
+++ b/content/start/case-study/figs/rf-lr-roc-curve-1.svg
@@ -208,7 +208,7 @@
   <path d="M 127.769531 44.675781 L 411.347656 44.675781 L 411.347656 328.253906 L 127.769531 328.253906 Z M 127.769531 44.675781 "/>
 </clipPath>
 </defs>
-<g id="surface169">
+<g id="surface179">
 <g clip-path="url(#clip1)" clip-rule="nonzero">
 <path style="fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;stroke-width:1.066978;stroke-linecap:round;stroke-linejoin:round;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:10;" d="M 87.171875 360 L 416.828125 360 L 416.828125 0 L 87.171875 0 Z M 87.171875 360 "/>
 </g>

--- a/content/start/case-study/figs/rf-results-1.svg
+++ b/content/start/case-study/figs/rf-results-1.svg
@@ -202,7 +202,7 @@
   <path d="M 272.300781 5.480469 L 498.519531 5.480469 L 498.519531 22.511719 L 272.300781 22.511719 Z M 272.300781 5.480469 "/>
 </clipPath>
 </defs>
-<g id="surface144">
+<g id="surface154">
 <rect x="0" y="0" width="504" height="288" style="fill:rgb(100%,100%,100%);fill-opacity:1;stroke:none;"/>
 <path style="fill:none;stroke-width:1.066978;stroke-linecap:round;stroke-linejoin:round;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:10;" d="M 0 288 L 504 288 L 504 0 L 0 0 Z M 0 288 "/>
 <g clip-path="url(#clip1)" clip-rule="nonzero">

--- a/content/start/case-study/figs/test-set-roc-curve-1.svg
+++ b/content/start/case-study/figs/test-set-roc-curve-1.svg
@@ -148,7 +148,7 @@
   <path d="M 108.171875 5.480469 L 430.949219 5.480469 L 430.949219 328.257812 L 108.171875 328.257812 Z M 108.171875 5.480469 "/>
 </clipPath>
 </defs>
-<g id="surface194">
+<g id="surface204">
 <g clip-path="url(#clip1)" clip-rule="nonzero">
 <path style="fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;stroke-width:1.066978;stroke-linecap:round;stroke-linejoin:round;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:10;" d="M 67.570312 360 L 436.425781 360 L 436.425781 0 L 67.570312 0 Z M 67.570312 360 "/>
 </g>

--- a/content/start/case-study/index.Rmarkdown
+++ b/content/start/case-study/index.Rmarkdown
@@ -198,14 +198,12 @@ lr_reg_grid %>% top_n(5)  # highest penalty values
 Let's use `tune::tune_grid()` to train these 30 penalized logistic regression models. We'll also save the validation set predictions (via the call to `control_grid()`) so that diagnostic information can be available after the model fit. The area under the ROC curve will be used to quantify how well the model performs across a continuum of event thresholds (recall that the event rate&mdash;the proportion of stays including children&mdash; is very low for these data). 
 
 ```{r logistic-fit, cache = TRUE}
-roc_only <- metric_set(roc_auc)
-
 lr_res <- 
   lr_workflow %>% 
   tune_grid(val_set,
             grid = lr_reg_grid,
             control = control_grid(save_pred = TRUE),
-            metrics = roc_only)
+            metrics = metric_set(roc_auc))
 ```
 
 It might be easier to visualize the validation set metrics by plotting the area under the ROC curve against the range of penalty values: 
@@ -369,7 +367,7 @@ rf_res <-
   tune_grid(val_set,
             grid = 25,
             control = control_grid(save_pred = TRUE),
-            metrics = roc_only)
+            metrics = metric_set(roc_auc))
 ```
 
 The message printed above *"Creating pre-processing data to finalize unknown parameter: mtry"* is related to the size of the data set. Since `mtry` depends on the number of predictors in the data set, `tune_grid()` determines the upper bound for `mtry` once it receives the data. 

--- a/content/start/case-study/index.markdown
+++ b/content/start/case-study/index.markdown
@@ -260,14 +260,12 @@ Let's use `tune::tune_grid()` to train these 30 penalized logistic regression mo
 
 
 ```r
-roc_only <- metric_set(roc_auc)
-
 lr_res <- 
   lr_workflow %>% 
   tune_grid(val_set,
             grid = lr_reg_grid,
             control = control_grid(save_pred = TRUE),
-            metrics = roc_only)
+            metrics = metric_set(roc_auc))
 ```
 
 It might be easier to visualize the validation set metrics by plotting the area under the ROC curve against the range of penalty values: 
@@ -458,7 +456,7 @@ rf_res <-
   tune_grid(val_set,
             grid = 25,
             control = control_grid(save_pred = TRUE),
-            metrics = roc_only)
+            metrics = metric_set(roc_auc))
 #> i Creating pre-processing data to finalize unknown parameter: mtry
 ```
 
@@ -655,7 +653,7 @@ Here are some more ideas for where to go next:
 #>  collate  en_US.UTF-8                 
 #>  ctype    en_US.UTF-8                 
 #>  tz       America/Denver              
-#>  date     2020-04-21                  
+#>  date     2020-04-29                  
 #> 
 #> ─ Packages ───────────────────────────────────────────────────────────────────
 #>  package    * version date       lib source        
@@ -663,6 +661,7 @@ Here are some more ideas for where to go next:
 #>  dials      * 0.0.6   2020-04-03 [1] CRAN (R 3.6.2)
 #>  dplyr      * 0.8.5   2020-03-07 [1] CRAN (R 3.6.0)
 #>  ggplot2    * 3.3.0   2020-03-05 [1] CRAN (R 3.6.0)
+#>  glmnet       3.0-2   2019-12-11 [1] CRAN (R 3.6.0)
 #>  infer      * 0.5.1   2019-11-19 [1] CRAN (R 3.6.0)
 #>  parsnip    * 0.1.0   2020-04-09 [1] CRAN (R 3.6.2)
 #>  purrr      * 0.3.4   2020-04-17 [1] CRAN (R 3.6.2)


### PR DESCRIPTION
In the "Get started" case study, you set an object `roc_only <- metric_set(roc_auc)` in the first model, then refer to it in the second much further down in the page. After coming back to that article, that is confusing, even for me who has read it deeply and repeatedly! It makes sense in the first model, but once you get down to the second you have to do a search on the page to figure out what `roc_only` does. I didn't render, so edits proposed only to `.Rmarkdown` for now.