### PR TITLE
Switch to SVG hex so the correct tidymodels hex image is used

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,7 +12,7 @@
       <div class="hexBadges">
         {{ $col0 := .Params.col0 }}
         {{ with $col0 }}
-        {{ with .row1 }}<a href="/"><div class=""></div><img src="https://raw.githubusercontent.com/rstudio/hex-stickers/master/PNG/{{ . }}.png" alt="{{ . }} hex sticker" class="r1 c0"></a>{{ end }}
+        {{ with .row1 }}<a href="/"><div class=""></div><img src="https://raw.githubusercontent.com/rstudio/hex-stickers/master/SVG/{{ . }}.svg" alt="{{ . }} hex sticker" class="r1 c0"></a>{{ end }}
         {{ with .row2 }}<a href="https://{{ $.Site.Params.hex_base_url }}{{ . }}"><div class="filtered r2 c0"></div><img src="https://raw.githubusercontent.com/rstudio/hex-stickers/master/PNG/{{ . }}.png" alt="{{ . }} hex sticker" class="r2 c0"></a>{{ end }}
         {{ with .row3 }}<a href="https://{{ $.Site.Params.hex_base_url }}{{ . }}"><div class="filtered r3 c0"></div><img src="https://raw.githubusercontent.com/rstudio/hex-stickers/master/PNG/{{ . }}.png" alt="{{ . }} hex sticker" class="r3 c0"></a>{{ end }}
         {{ end }}


### PR DESCRIPTION
The PNG version was showing a serif font (see below)

[![image](https://user-images.githubusercontent.com/29008894/81840160-959af100-9516-11ea-8ab6-357d07539919.png)](https://raw.githubusercontent.com/rstudio/hex-stickers/master/PNG/tidymodels.png)
