### PR TITLE
add article on writing broom tidiers

### DIFF
--- a/content/learn/develop/broom/index.Rmarkdown
+++ b/content/learn/develop/broom/index.Rmarkdown
@@ -1,5 +1,5 @@
 ---
-title: "Create your own broom tidiers"
+title: "Create your own broom tidier methods"
 tags: [broom]
 categories: []
 type: learn-subsection
@@ -30,13 +30,13 @@ The broom package provides tools to summarize key information about models in ti
 * `glance()` reports information about the entire model
 * `augment()` adds information about observations to a dataset
 
-Each of the three verbs above are _generic_, in that they do not define a procedure to tidy a given model object, but instead redirect to the relevant _method_ implemented to tidy a specific type of model object. The broom package provides tidier methods for model objects from over 100 modeling packages along with nearly all of the model objects in the stats package that comes with base R. However, for maintainability purposes, the broom package authors now ask that requests for new tidier methods be first directed to the parent package (i.e. the package that supplies the model object) rather than to broom. Tidiers will generally only be integrated into broom in the case that the requester has already asked the maintainers of the model-owning package to implement tidiers in the parent package.
+Each of the three verbs above are _generic_, in that they do not define a procedure to tidy a given model object, but instead redirect to the relevant _method_ implemented to tidy a specific type of model object. The broom package provides methods for model objects from over 100 modeling packages along with nearly all of the model objects in the stats package that comes with base R. However, for maintainability purposes, the broom package authors now ask that requests for new methods be first directed to the parent package (i.e. the package that supplies the model object) rather than to broom. New methods will generally only be integrated into broom in the case that the requester has already asked the maintainers of the model-owning package to implement tidier methods in the parent package.
 
 We'd like to make implementing external tidier methods as painless as possible. The general process for doing so is:
 
 * re-export the tidier generics
 * implement tidying methods
-* document the new tidiers
+* document the new methods
 
 In this article, we'll walk through each of the above steps in detail, giving examples and pointing out helpful functions when possible.
 
@@ -64,7 +64,7 @@ Oftentimes it doesn't make sense to define one or more of these methods for a pa
 
 ## Implement tidying methods
 
-You'll now need to implement specific tidying methods for each of the tidiers you've re-exported in the above step. For each of `tidy()`, `glance()`, and `augment()`, we'll walk through the big picture, an example, and helpful resources.
+You'll now need to implement specific tidying methods for each of the generics you've re-exported in the above step. For each of `tidy()`, `glance()`, and `augment()`, we'll walk through the big picture, an example, and helpful resources.
 
 In this article, we'll use the base R dataset `trees`, giving the tree girth (in inches), height (in feet), and volume (in cubic feet), to fit an example linear model using the base R `lm()` function. 
 
@@ -87,7 +87,7 @@ summary(trees_model)
 
 This output gives some summary statistics on the residuals (which would be described more fully in an `augment()` output), model coefficients (which, in this case, make up the `tidy()` output), and some model-level summarizations such as RSE, $R^2$, etc. (which make up the `glance()` output.)
 
-### Implementing the `tidy()` Tidier
+### Implementing the `tidy()` method
 
 The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the dots (`...`) are an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These `tidy()` methods are useful for inspecting model details and creating custom model visualizations.
 
@@ -161,7 +161,7 @@ tidy(model, effects = "random")
   - `conf.level`: The confidence level to use for the interval when `conf.int = TRUE`. Typically defaults to `.95`.
   - `exponentiate`: A logical indicating whether or not model terms should be presented on an exponential scale (typical for logistic regression).
 
-### Implementing the `glance()` Tidier
+### Implementing the `glance()` method
 
 `glance()` returns a one-row tibble providing model-level summarizations (e.g. goodness of fitness measures and related statistics). This is useful to check for model misspecification and to compare many models. Again, the `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `glance()` methods can also take additional arguments and _must_ include the `x` and `...` arguments. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)
 
@@ -221,7 +221,7 @@ Some things to keep in mind while writing `glance()` methods:
 * In some cases, you may wish to provide model-level diagnostics not returned by the original object. For example, the above `glance.lm()` calculates `AIC` and `BIC` from the model fit. If these are easy to compute, feel free to add them. However, tidier methods are generally not an appropriate place to implement complex or time consuming calculations.
 * The `glance` method should always return the same columns in the same order when given an object of a given model class. If a summary metric (such as `AIC`) is not defined in certain circumstances, use `NA`.
 
-### Implementing the `augment()` Tidier
+### Implementing the `augment()` method
 
 `augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata` argument, following the same conventions as the `data` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata` arguments need not contain the response columns in `data`. Only one of `data` or `newdata` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
 
@@ -278,9 +278,9 @@ Some other things to keep in mind while writing `augment()` methods:
 
 {{% note %}} The recommended interface and functionality for `augment()` methods may change soon. {{%/ note %}}
 
-## Document the new tidiers
+## Document the new methods
 
-The only remaining step is to integrate the new tidiers into the parent package! To do so, just drop the tidiers into a `.R` file inside of the `/R` folder and document them using roxygen2. If you're unfamiliar with the process of documenting objects, you can read more about it [here](http://r-pkgs.had.co.nz/man.html). Here's an example of how our `tidy.lm()` method might be documented:
+The only remaining step is to integrate the new methods into the parent package! To do so, just drop the methods into a `.R` file inside of the `/R` folder and document them using roxygen2. If you're unfamiliar with the process of documenting objects, you can read more about it [here](http://r-pkgs.had.co.nz/man.html). Here's an example of how our `tidy.lm()` method might be documented:
 
 ```{r, eval = FALSE}
 #' Tidy a(n) lm object
@@ -312,7 +312,7 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   # ... the rest of the function definition goes here!
 ```
 
-Once you've documented each of your new tidiers and executed `devtools::document()`, you're done! Congrats on implementing your own broom tidiers for a new model object!
+Once you've documented each of your new methods and executed `devtools::document()`, you're done! Congrats on implementing your own broom tidier methods for a new model object!
 
 ## Glossaries: Argument and Column Names {#glossary}
 

--- a/content/learn/develop/broom/index.Rmarkdown
+++ b/content/learn/develop/broom/index.Rmarkdown
@@ -1,0 +1,316 @@
+---
+title: "Create your own broom tidiers"
+tags: [broom]
+categories: []
+type: learn-subsection
+weight: 2
+description: | 
+  Write tidy(), glance(), and augment() methods for new model objects.
+---
+
+```{r setup, include = FALSE, message = FALSE, warning = FALSE}
+source(here::here("content/learn/common.R"))
+```
+
+```{r load, include = FALSE, message = FALSE, warning = FALSE}
+library(tidymodels)
+library(generics)
+
+pkgs <- c("tidymodels", "generics")
+```
+
+## Introduction
+
+`r req_pkgs(pkgs)`
+
+The broom package provides tools to summarize key information about models in tidy `tibble()`s. The package provides three verbs, or "tidiers," to help make model objects easier to work with:
+
+* `tidy()` summarizes information about model components
+* `glance()` reports information about the entire model
+* `augment()` adds information about observations to a dataset
+
+Each of the three verbs above are _generic_, in that they do not actually define a procedure to tidy a given model object, but instead redirect to the relevant _method_ implemented to tidy a specific type of model object. The package provides tidier methods for model objects from over 100 modeling packages and nearly all of the model objects in the stats package that comes with base R. However, for maintainability purposes, the broom package authors now ask that requests for new tidier methods be first directed to the parent package (i.e. the package that supplies the model object) rather than to broom. Tidiers will generally only be integrated into broom in the case that the requester has already asked the maintainers of the model-owning package to implement tidiers in the parent package.
+
+As a result, we'd like to make implementing external tidier methods as painless as possible. The general process for doing so is as follows:
+
+* re-export the tidier generics
+* implement tidying methods
+* document the new tidiers
+
+In this article, we'll walk through each of the above steps in detail, giving examples and pointing out helpful functions when possible.
+
+## Re-export the Tidier Generics
+
+The first step is to re-export the generic functions for `tidy()`, `glance()`, and/or `augment()`. You could do so from `broom` itself, but we've provided an alternative, much lighter dependency called `modelgenerics`.
+
+First you'll need to add the [modelgenerics](https://github.com/tidymodels/modelgenerics) package to `Imports`. We recommend using the [usethis](https://github.com/r-lib/usethis) package for this:
+
+```{r, eval = FALSE}
+usethis::use_package("generics", "Imports")
+```
+
+Next, you'll need to re-export the appropriate tidying methods. If you plan to implement a `glance()` method, for example, you can re-export the `glance()` generic by adding the following somewhere inside the `/R` folder of your package:
+
+```{r, eval = FALSE}
+#' @importFrom generics glance
+#' @export
+generics::glance
+```
+
+Oftentimes it doesn't make sense to define one or more of these methods for a particular model. In this case, just implement the methods that do make sense.
+
+Note: please do not define `tidy()`, `glance()` or `augment()` generics in your package. This will result in namespace conflicts whenever your package is used along other packages that also export tidying methods.
+
+## Implement Tidying Methods
+
+You'll now need to implement specific tidying methods for each of the tidiers you've re-exported in the above step. For each of `tidy()`, `glance()`, and `augment()`, we'll walk through the big picture, an example, and helpful resources.
+
+In this article, we'll use the base R dataset `trees`, giving the tree girth (in inches), height (in feet), and volume (in cubic feet), to fit an example linear model using the base R `lm()` function. 
+
+```{r}
+# load in the trees dataset
+data(trees)
+
+# take a look!
+str(trees)
+
+# fit the timber volume as a function of girth and height
+trees_model <- lm(Volume ~ Girth + Height, data = trees)
+```
+
+Let's take a look at the `summary()` of our `trees_model` fit.
+
+```{r}
+summary(trees_model)
+```
+
+This output gives some summary statistics on the residuals (which would be described more fully in an `augment()` output), model coefficients (which, in this case, make up the `tidy()` output, and some model-level summarizations such as RSE, $R^2$, etc. (which make up the `glance()` output.)
+
+### Implementing the `tidy()` Tidier
+
+The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [this dataframe](https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These methods are useful for inspecting model details and creating custom model visualizations.
+
+Returning to the example of our linear model on timber volume, we'd like to extract information on the model components. In this example, the components are the regression coefficients. After taking a look at the model object and its `summary()`, you might notice that you can extract the regression coefficients as follows:
+
+```{r}
+summary(trees_model)$coefficients
+```
+
+This object contains the model coefficients as a table, where the information giving which coefficient is being described in each row is given in the row names. Converting to a tibble where the row names are contained in a column, you might write:
+
+```{r}
+trees_model_tidy <- summary(trees_model)$coefficients %>% 
+  as_tibble(rownames = "term")
+
+trees_model_tidy
+```
+
+broom standardizes common column names used to described coefficients. In this case, the column names are:
+
+```{r}
+colnames(trees_model_tidy) <- c("term", "estimate", "std.error", "statistic", "p.value")
+```
+
+A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [here](https://github.com/alexpghayes/modeltests/blob/master/data/column_glossary.rda). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
+
+Finally, it is common for `tidy()` methods to include an option to calculate confidence/credible interval for each component based on the model, when possible. In this case, the `confint()` function can be used to calculate confidence intervals from a model object resulting from `lm()`:
+
+```{r}
+confint(trees_model)
+```
+
+With these considerations in mind, a reasonable `tidy()` method for `lm()` might look something like:
+
+```{r, eval = FALSE}
+tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
+  
+  result <- summary(x)$coefficients %>%
+    tibble::as_tibble(rownames = "term") %>%
+    dplyr::rename(estimate = Estimate,
+                  std.error = `Std. Error`,
+                  statistic = `t value`,
+                  p.value = `Pr(>|t|)`)
+  
+  if (conf.int) {
+    ci <- confint(x, level = conf.level)
+    result <- dplyr::left_join(result, ci, by = "term")
+  }
+  
+  result
+}
+```
+
+With this method exported, then, if a user called `tidy(fit)`, where `fit` was an output from `lm()`, the `tidy()` generic would "redirect" the call to the `tidy.lm()` function above.
+
+Some things to keep in mind while writing your `tidy()` method:
+
+* Sometimes a model will have several different types of components. For example, in mixed models, there is different information associated with fixed effects and random effects, since this information doesn't have the same interpretation, it doesn't make sense to summarize the fixed and random effects in the same table. In cases like this you should add an argument that allows the user to specify which type of information they want. For example, you might implement an interface along the lines of:
+
+```{r eval = FALSE}
+model <- mixed_model(...)
+tidy(model, effects = "fixed")
+tidy(model, effects = "random")
+```
+
+* How are missing values encoded in the model object and its `summary()`? Ensure that rows are included even when the associated model component is missing or rank deficient.
+* Are there other measures specific to each component that could reasonably be expected to be included in their summarizations? Some common arguments to `tidy()` methods include:
+  - `conf.int`: A logical indicating whether or not to calculate confidence/credible intervals. This should default to `FALSE`.
+  - `conf.level`: The confidence level to use for the interval when `conf.int = TRUE`. Typically defaults to `.95`.
+  - `exponentiate`: A logical indicating whether or not model terms should be presented on an exponential scale (typical for logistic regression).
+
+### Implementing the `glance()` Tidier
+
+`glance()` returns a one-row tibble providing model-level summarizations (e.g. goodness of fitness measures and related statistics). This is useful to check for model misspecification and to compare many models. Again, the `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `glance()` methods can also take additional arguments and _must_ include the `x` and `...` arguments. (For a glossary of currently acceptable additional arguments, see [this dataframe](https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda).)
+
+Returning to the `trees_model` example, we could pull out the $R^2$ value with the following code:
+
+```{r}
+summary(trees_model)$r.squared
+```
+
+Similarly, for the adjusted $R^2$:
+
+```{r}
+summary(trees_model)$adj.r.squared
+```
+
+Unfortunately, for many model objects, the extraction of model-level information is largely a manual process. You will likely need to build a `tibble()` element-by-element by subsetting the `summary()` object repeatedly. The `with()` function, however, can help make this process a bit less tedious by evaluating expressions inside of the `summary(trees_model)` environment. To grab those those same two model elements from above using `with()`:
+
+```{r}
+with(summary(trees_model),
+     tibble::tibble(r.squared = r.squared,
+                    adj.r.squared = adj.r.squared))
+```
+
+A reasonable `glance()` method for `lm()`, then, might look something like:
+
+```{r, eval = FALSE}
+glance.lm <- function(x, ...) {
+  with(
+    summary(x),
+    tibble::tibble(
+      r.squared = r.squared,
+      adj.r.squared = adj.r.squared,
+      sigma = sigma,
+      statistic = fstatistic["value"],
+      p.value = pf(
+        fstatistic["value"],
+        fstatistic["numdf"],
+        fstatistic["dendf"],
+        lower.tail = FALSE
+      ),
+      df = fstatistic["numdf"],
+      logLik = as.numeric(stats::logLik(x)),
+      AIC = stats::AIC(x),
+      BIC = stats::BIC(x),
+      deviance = stats::deviance(x),
+      df.residual = df.residual(x),
+      nobs = stats::nobs(x)
+    )
+  )
+}
+```
+
+In fact, this is the actual definition of `glance.lm()` provided by broom!
+
+Some things to keep in mind while writing `glance()` methods:
+* Output should not include the name of the modeling function or any arguments given to the modelling function.
+* In some cases, you may wish to provide model-level diagnostics not returned by the original object. For example, the above `glance.lm()` calculates `AIC` and `BIC` from the model fit. If these are easy to compute, feel free to add them. However, tidier methods are generally not an appropriate place to implement complex or time consuming calculations.
+* `glance` should always return the same columns in the same order when given an object of a given model class. If a summary metric (such as `AIC`) is not defined in certain circumstances, use `NA`.
+
+### Implementing the `augment()` Tidier
+
+`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given [here](https://github.com/alexpghayes/modeltests/blob/master/data/column_glossary.rda).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found [here](https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda).
+
+If a `data` argument is not specified, `augment` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
+
+With this is mind, we can look back to our `trees_model` example. For one, the `model` element inside of the `trees_model` object will allow us to recover the original data:
+
+```{r, rows.print=5}
+trees_model$model
+```
+
+
+Similarly, the fitted values and residuals can be accessed with the following code:
+
+```{r}
+head(trees_model$fitted.values)
+head(trees_model$residuals)
+```
+
+As with `glance()` methods, it's fine (and encouraged!) to include common metrics associated with observations if they are not computationally intensive to compute. A common metric associated with linear models, for example, is the standard error of fitted values:
+
+```{r}
+se.fit <- predict(trees_model, newdata = trees, se.fit = TRUE)$se.fit %>%
+  unname()
+
+head(se.fit)
+```
+
+Thus, a reasonable `augment()` method for `lm` might look something like this:
+
+```{r}
+augment.lm <- function(x, data = x$model, newdata = NULL, ...) {
+  if (is.null(newdata)) {
+    dplyr::bind_cols(tibble::as_tibble(data),
+                     tibble::tibble(.fitted = x$fitted.values,
+                                    .se.fit = predict(x, 
+                                                      newdata = data, 
+                                                      se.fit = TRUE)$se.fit,
+                                   .resid =  x$residuals))
+  } else {
+    predictions <- predict(x, newdata = newdata, se.fit = TRUE)
+    dplyr::bind_cols(tibble::as_tibble(newdata),
+                     tibble::tibble(.fitted = predictions$fit,
+                                    .se.fit = predictions$se.fit))
+  }
+}
+```
+
+Some other things to keep in mind while writing `augment()` methods:
+* The `newdata` argument should default to `NULL`. Users should only ever specify one of `data` or `newdata`. Providing both `data` and `newdata` should result in an error. `newdata` should accept both `data.frame`s and `tibble`s.
+* Data given to the `data` argument must have both the original predictors and the original response. Data given to the `newdata` argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
+* If the `data` or `newdata` is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
+* For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
+
+Please note that the recommended interface and functionality for `augment()` methods may change soon.
+
+## Document the new tidiers
+
+The only remaining step is to integrate the new tidiers into the parent package! To do so, just drop the tidiers into a `.R` file inside of the $/R$ folder and document them using roxygen2. If you're unfamiliar with the process of documenting objects, you can read more about it [here](http://r-pkgs.had.co.nz/man.html). Here's an example of how our `tidy.lm()` method might be documented:
+
+```{r, eval = FALSE}
+#' Tidy a(n) lm object
+#'
+#' @param x A `lm` object.
+#' @param conf.int Logical indicating whether or not to include 
+#'   a confidence interval in the tidied output. Defaults to FALSE.
+#' @param conf.level The confidence level to use for the confidence 
+#'   interval if conf.int = TRUE. Must be strictly greater than 0 
+#'   and less than 1. Defaults to 0.95, which corresponds to a 
+#'   95 percent confidence interval.
+#' @param ... Unused, included for generic consistency only.
+#'
+#' @examples
+#' # load the trees dataset
+#' data(trees)
+#' 
+#' # fit a linear model on timber volume
+#' trees_model <- lm(Volume ~ Girth + Height, data = trees)
+#'
+#' # summarize model coefficients in a tidy tibble!
+#' tidy(trees_model)
+#'
+#' @export
+tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
+
+  # ... the rest of the function definition goes here!
+```
+
+Once you've documented each of your new tidiers and ran `devtools::document()`, you're done! Congrats on implementing your own broom tidiers for a new model object!
+
+## Session information
+
+```{r si, echo = FALSE}
+small_session(pkgs)
+```

--- a/content/learn/develop/broom/index.Rmarkdown
+++ b/content/learn/develop/broom/index.Rmarkdown
@@ -223,9 +223,9 @@ Some things to keep in mind while writing `glance()` methods:
 
 ### Implementing the `augment()` Tidier
 
-`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a data argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as data. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
+`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata` argument, following the same conventions as the `data` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata` arguments need not contain the response columns in `data`. Only one of `data` or `newdata` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
 
-If a data argument is not specified, `augment()` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
+If a `data` argument is not specified, `augment()` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
 
 With this is mind, we can look back to our `trees_model` example. For one, the `model` element inside of the `trees_model` object will allow us to recover the original data:
 
@@ -270,11 +270,11 @@ augment.lm <- function(x, data = x$model, newdata = NULL, ...) {
 ```
 
 Some other things to keep in mind while writing `augment()` methods:
-* The newdata argument should default to `NULL`. Users should only ever specify one of data or newdata. Providing both data and newdata should result in an error. The newdata argument should accept both `data.frame`s and `tibble`s.
-* Data given to the data argument must have both the original predictors and the original response. Data given to the newdata argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
-* If the data or newdata is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
+* The `newdata` argument should default to `NULL`. Users should only ever specify one of `data` or `newdata`. Providing both `data` and `newdata` should result in an error. The `newdata` argument should accept both `data.frame`s and `tibble`s.
+* Data given to the `data` argument must have both the original predictors and the original response. Data given to the `newdata` argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
+* If the `data` or `newdata` is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
 * For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
-* *The `augment()` method should always return as many rows as were in data or newdata*, depending on which is supplied
+* *The `augment()` method should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
 
 {{% note %}} The recommended interface and functionality for `augment()` methods may change soon. {{%/ note %}}
 

--- a/content/learn/develop/broom/index.Rmarkdown
+++ b/content/learn/develop/broom/index.Rmarkdown
@@ -60,7 +60,7 @@ generics::glance
 
 Oftentimes it doesn't make sense to define one or more of these methods for a particular model. In this case, just implement the methods that do make sense.
 
-Note: please do not define `tidy()`, `glance()` or `augment()` generics in your package. This will result in namespace conflicts whenever your package is used along other packages that also export tidying methods.
+{{% warning %}} Please do not define `tidy()`, `glance()` or `augment()` generics in your package. This will result in namespace conflicts whenever your package is used along other packages that also export tidying methods. {{%/ warning %}}
 
 ## Implement Tidying Methods
 
@@ -114,7 +114,7 @@ colnames(trees_model_tidy) <- c("term", "estimate", "std.error", "statistic", "p
 
 A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [at the end of this article](#glossary)). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
 
-Finally, it is common for `tidy()` methods to include an option to calculate confidence/credible interval for each component based on the model, when possible. In this case, the `confint()` function can be used to calculate confidence intervals from a model object resulting from `lm()`:
+Finally, it is common for `tidy()` methods to include an option to calculate confidence/credible intervals for each component based on the model, when possible. In this example, the `confint()` function can be used to calculate confidence intervals from a model object resulting from `lm()`:
 
 ```{r}
 confint(trees_model)
@@ -140,6 +140,8 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   result
 }
 ```
+
+{{% note %}}  If you're interested, the actual `tidy.lm()` source can be found [here](https://github.com/tidymodels/broom/blob/master/R/stats-lm-tidiers.R)! It's not too different from the version above except for some argument checking and additional columns. {{%/ note %}}
 
 With this method exported, then, if a user called `tidy(fit)`, where `fit` was an output from `lm()`, the `tidy()` generic would "redirect" the call to the `tidy.lm()` function above.
 
@@ -212,7 +214,7 @@ glance.lm <- function(x, ...) {
 }
 ```
 
-In fact, this is the actual definition of `glance.lm()` provided by broom!
+{{% note %}} This is the actual definition of `glance.lm()` provided by broom! {{%/ note %}}
 
 Some things to keep in mind while writing `glance()` methods:
 * Output should not include the name of the modeling function or any arguments given to the modelling function.
@@ -230,7 +232,6 @@ With this is mind, we can look back to our `trees_model` example. For one, the `
 ```{r, rows.print=5}
 trees_model$model
 ```
-
 
 Similarly, the fitted values and residuals can be accessed with the following code:
 
@@ -275,7 +276,7 @@ Some other things to keep in mind while writing `augment()` methods:
 * For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
 * *`augment()` should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
 
-Please note that the recommended interface and functionality for `augment()` methods may change soon.
+{{% note %}} The recommended interface and functionality for `augment()` methods may change soon. {{%/ note %}}
 
 ## Document the new tidiers
 

--- a/content/learn/develop/broom/index.Rmarkdown
+++ b/content/learn/develop/broom/index.Rmarkdown
@@ -14,7 +14,9 @@ source(here::here("content/learn/common.R"))
 
 ```{r load, include = FALSE, message = FALSE, warning = FALSE}
 library(tidymodels)
+library(tidyverse)
 library(generics)
+library(kableExtra)
 pkgs <- c("tidymodels", "tidyverse", "generics", "usethis")
 ```
 
@@ -40,9 +42,9 @@ In this article, we'll walk through each of the above steps in detail, giving ex
 
 ## Re-export the Tidier Generics
 
-The first step is to re-export the generic functions for `tidy()`, `glance()`, and/or `augment()`. You could do so from `broom` itself, but we've provided an alternative, much lighter dependency called `modelgenerics`.
+The first step is to re-export the generic functions for `tidy()`, `glance()`, and/or `augment()`. You could do so from `broom` itself, but we've provided an alternative, much lighter dependency called `generics`.
 
-First you'll need to add the [modelgenerics](https://github.com/tidymodels/modelgenerics) package to `Imports`. We recommend using the [usethis](https://github.com/r-lib/usethis) package for this:
+First you'll need to add the [generics](https://github.com/tidymodels/generics) package to `Imports`. We recommend using the [usethis](https://github.com/r-lib/usethis) package for this:
 
 ```{r, eval = FALSE}
 usethis::use_package("generics", "Imports")
@@ -87,7 +89,7 @@ This output gives some summary statistics on the residuals (which would be descr
 
 ### Implementing the `tidy()` Tidier
 
-The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [this dataframe](https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These methods are useful for inspecting model details and creating custom model visualizations.
+The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These methods are useful for inspecting model details and creating custom model visualizations.
 
 Returning to the example of our linear model on timber volume, we'd like to extract information on the model components. In this example, the components are the regression coefficients. After taking a look at the model object and its `summary()`, you might notice that you can extract the regression coefficients as follows:
 
@@ -110,7 +112,7 @@ broom standardizes common column names used to described coefficients. In this c
 colnames(trees_model_tidy) <- c("term", "estimate", "std.error", "statistic", "p.value")
 ```
 
-A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [here](https://github.com/alexpghayes/modeltests/blob/master/data/column_glossary.rda). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
+A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [at the end of this article](#glossary)). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
 
 Finally, it is common for `tidy()` methods to include an option to calculate confidence/credible interval for each component based on the model, when possible. In this case, the `confint()` function can be used to calculate confidence intervals from a model object resulting from `lm()`:
 
@@ -159,7 +161,7 @@ tidy(model, effects = "random")
 
 ### Implementing the `glance()` Tidier
 
-`glance()` returns a one-row tibble providing model-level summarizations (e.g. goodness of fitness measures and related statistics). This is useful to check for model misspecification and to compare many models. Again, the `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `glance()` methods can also take additional arguments and _must_ include the `x` and `...` arguments. (For a glossary of currently acceptable additional arguments, see [this dataframe](https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda).)
+`glance()` returns a one-row tibble providing model-level summarizations (e.g. goodness of fitness measures and related statistics). This is useful to check for model misspecification and to compare many models. Again, the `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `glance()` methods can also take additional arguments and _must_ include the `x` and `...` arguments. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)
 
 Returning to the `trees_model` example, we could pull out the $R^2$ value with the following code:
 
@@ -219,7 +221,7 @@ Some things to keep in mind while writing `glance()` methods:
 
 ### Implementing the `augment()` Tidier
 
-`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given [here](https://github.com/alexpghayes/modeltests/blob/master/data/column_glossary.rda).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found [here](https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda).
+`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
 
 If a `data` argument is not specified, `augment` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
 
@@ -271,6 +273,7 @@ Some other things to keep in mind while writing `augment()` methods:
 * Data given to the `data` argument must have both the original predictors and the original response. Data given to the `newdata` argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
 * If the `data` or `newdata` is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
 * For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
+* *`augment()` should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
 
 Please note that the recommended interface and functionality for `augment()` methods may change soon.
 
@@ -289,6 +292,8 @@ The only remaining step is to integrate the new tidiers into the parent package!
 #'   and less than 1. Defaults to 0.95, which corresponds to a 
 #'   95 percent confidence interval.
 #' @param ... Unused, included for generic consistency only.
+#' @return A tidy [tibble::tibble()] summarizing component-level
+#'   information about the model
 #'
 #' @examples
 #' # load the trees dataset
@@ -307,6 +312,49 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
 ```
 
 Once you've documented each of your new tidiers and ran `devtools::document()`, you're done! Congrats on implementing your own broom tidiers for a new model object!
+
+## Glossaries: Argument and Column Names {#glossary}
+
+```{r, include = FALSE}
+# grab the argument glossary: make a temporary file, write the
+# data to it, load it, and then delete it
+args_url <- "https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda?raw=true"
+args_file <- tempfile()
+args_get <- httr::GET(args_url)
+httr::stop_for_status(args_get)
+writeBin(httr::content(args_get, type = "raw"), args_file)
+load(args_file)
+unlink(args_file)
+
+# do the same thing for the columns
+cols_url <- "https://github.com/alexpghayes/modeltests/blob/master/data/column_glossary.rda?raw=true"
+cols_file <- tempfile()
+cols_get <- httr::GET(cols_url)
+httr::stop_for_status(cols_get)
+writeBin(httr::content(cols_get, type = "raw"), cols_file)
+load(cols_file)
+unlink(cols_file)
+```
+
+Tidier methods have a standardized set of acceptable argument and output column names. The currently acceptable argument names by tidier method are:
+
+```{r, echo = FALSE}
+argument_glossary %>%
+  select(Method = method, Argument = argument) %>%
+  knitr::kable() %>%
+  kable_styling(full_width = FALSE)
+```
+
+The currently acceptable column names by tidier method are:
+
+```{r, echo = FALSE}
+column_glossary %>%
+  select(Method = method, Column = column) %>%
+  knitr::kable() %>%
+  kable_styling(full_width = FALSE)
+```
+
+Please file an issue at [alexpghayes/modeltests](https://github.com/alexpghayes/modeltests) to request new arguments/columns to be added to the glossaries.
 
 ## Session information
 

--- a/content/learn/develop/broom/index.Rmarkdown
+++ b/content/learn/develop/broom/index.Rmarkdown
@@ -30,9 +30,9 @@ The broom package provides tools to summarize key information about models in ti
 * `glance()` reports information about the entire model
 * `augment()` adds information about observations to a dataset
 
-Each of the three verbs above are _generic_, in that they do not actually define a procedure to tidy a given model object, but instead redirect to the relevant _method_ implemented to tidy a specific type of model object. The package provides tidier methods for model objects from over 100 modeling packages and nearly all of the model objects in the stats package that comes with base R. However, for maintainability purposes, the broom package authors now ask that requests for new tidier methods be first directed to the parent package (i.e. the package that supplies the model object) rather than to broom. Tidiers will generally only be integrated into broom in the case that the requester has already asked the maintainers of the model-owning package to implement tidiers in the parent package.
+Each of the three verbs above are _generic_, in that they do not define a procedure to tidy a given model object, but instead redirect to the relevant _method_ implemented to tidy a specific type of model object. The broom package provides tidier methods for model objects from over 100 modeling packages along with nearly all of the model objects in the stats package that comes with base R. However, for maintainability purposes, the broom package authors now ask that requests for new tidier methods be first directed to the parent package (i.e. the package that supplies the model object) rather than to broom. Tidiers will generally only be integrated into broom in the case that the requester has already asked the maintainers of the model-owning package to implement tidiers in the parent package.
 
-As a result, we'd like to make implementing external tidier methods as painless as possible. The general process for doing so is as follows:
+We'd like to make implementing external tidier methods as painless as possible. The general process for doing so is:
 
 * re-export the tidier generics
 * implement tidying methods
@@ -40,7 +40,7 @@ As a result, we'd like to make implementing external tidier methods as painless 
 
 In this article, we'll walk through each of the above steps in detail, giving examples and pointing out helpful functions when possible.
 
-## Re-export the Tidier Generics
+## Re-export the tidier generics
 
 The first step is to re-export the generic functions for `tidy()`, `glance()`, and/or `augment()`. You could do so from `broom` itself, but we've provided an alternative, much lighter dependency called `generics`.
 
@@ -58,11 +58,11 @@ Next, you'll need to re-export the appropriate tidying methods. If you plan to i
 generics::glance
 ```
 
-Oftentimes it doesn't make sense to define one or more of these methods for a particular model. In this case, just implement the methods that do make sense.
+Oftentimes it doesn't make sense to define one or more of these methods for a particular model. In this case, only implement the methods that do make sense.
 
-{{% warning %}} Please do not define `tidy()`, `glance()` or `augment()` generics in your package. This will result in namespace conflicts whenever your package is used along other packages that also export tidying methods. {{%/ warning %}}
+{{% warning %}} Please do not define `tidy()`, `glance()`, or `augment()` generics in your package. This will result in namespace conflicts whenever your package is used along other packages that also export tidying methods. {{%/ warning %}}
 
-## Implement Tidying Methods
+## Implement tidying methods
 
 You'll now need to implement specific tidying methods for each of the tidiers you've re-exported in the above step. For each of `tidy()`, `glance()`, and `augment()`, we'll walk through the big picture, an example, and helpful resources.
 
@@ -85,11 +85,11 @@ Let's take a look at the `summary()` of our `trees_model` fit.
 summary(trees_model)
 ```
 
-This output gives some summary statistics on the residuals (which would be described more fully in an `augment()` output), model coefficients (which, in this case, make up the `tidy()` output, and some model-level summarizations such as RSE, $R^2$, etc. (which make up the `glance()` output.)
+This output gives some summary statistics on the residuals (which would be described more fully in an `augment()` output), model coefficients (which, in this case, make up the `tidy()` output), and some model-level summarizations such as RSE, $R^2$, etc. (which make up the `glance()` output.)
 
 ### Implementing the `tidy()` Tidier
 
-The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These methods are useful for inspecting model details and creating custom model visualizations.
+The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the dots (`...`) are an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These `tidy()` methods are useful for inspecting model details and creating custom model visualizations.
 
 Returning to the example of our linear model on timber volume, we'd like to extract information on the model components. In this example, the components are the regression coefficients. After taking a look at the model object and its `summary()`, you might notice that you can extract the regression coefficients as follows:
 
@@ -106,13 +106,13 @@ trees_model_tidy <- summary(trees_model)$coefficients %>%
 trees_model_tidy
 ```
 
-broom standardizes common column names used to described coefficients. In this case, the column names are:
+The broom package standardizes common column names used to describe coefficients. In this case, the column names are:
 
 ```{r}
 colnames(trees_model_tidy) <- c("term", "estimate", "std.error", "statistic", "p.value")
 ```
 
-A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [at the end of this article](#glossary)). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
+A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [at the end of this article](#glossary). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
 
 Finally, it is common for `tidy()` methods to include an option to calculate confidence/credible intervals for each component based on the model, when possible. In this example, the `confint()` function can be used to calculate confidence intervals from a model object resulting from `lm()`:
 
@@ -143,11 +143,11 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
 
 {{% note %}}  If you're interested, the actual `tidy.lm()` source can be found [here](https://github.com/tidymodels/broom/blob/master/R/stats-lm-tidiers.R)! It's not too different from the version above except for some argument checking and additional columns. {{%/ note %}}
 
-With this method exported, then, if a user called `tidy(fit)`, where `fit` was an output from `lm()`, the `tidy()` generic would "redirect" the call to the `tidy.lm()` function above.
+With this method exported, then, if a user calls `tidy(fit)`, where `fit` is an output from `lm()`, the `tidy()` generic would "redirect" the call to the `tidy.lm()` function above.
 
 Some things to keep in mind while writing your `tidy()` method:
 
-* Sometimes a model will have several different types of components. For example, in mixed models, there is different information associated with fixed effects and random effects, since this information doesn't have the same interpretation, it doesn't make sense to summarize the fixed and random effects in the same table. In cases like this you should add an argument that allows the user to specify which type of information they want. For example, you might implement an interface along the lines of:
+* Sometimes a model will have several different types of components. For example, in mixed models, there is different information associated with fixed effects and random effects. Since this information doesn't have the same interpretation, it doesn't make sense to summarize the fixed and random effects in the same table. In cases like this you should add an argument that allows the user to specify which type of information they want. For example, you might implement an interface along the lines of:
 
 ```{r eval = FALSE}
 model <- mixed_model(...)
@@ -217,15 +217,15 @@ glance.lm <- function(x, ...) {
 {{% note %}} This is the actual definition of `glance.lm()` provided by broom! {{%/ note %}}
 
 Some things to keep in mind while writing `glance()` methods:
-* Output should not include the name of the modeling function or any arguments given to the modelling function.
+* Output should not include the name of the modeling function or any arguments given to the modeling function.
 * In some cases, you may wish to provide model-level diagnostics not returned by the original object. For example, the above `glance.lm()` calculates `AIC` and `BIC` from the model fit. If these are easy to compute, feel free to add them. However, tidier methods are generally not an appropriate place to implement complex or time consuming calculations.
-* `glance` should always return the same columns in the same order when given an object of a given model class. If a summary metric (such as `AIC`) is not defined in certain circumstances, use `NA`.
+* The `glance` method should always return the same columns in the same order when given an object of a given model class. If a summary metric (such as `AIC`) is not defined in certain circumstances, use `NA`.
 
 ### Implementing the `augment()` Tidier
 
 `augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
 
-If a `data` argument is not specified, `augment` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
+If a `data` argument is not specified, `augment()` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
 
 With this is mind, we can look back to our `trees_model` example. For one, the `model` element inside of the `trees_model` object will allow us to recover the original data:
 
@@ -270,17 +270,17 @@ augment.lm <- function(x, data = x$model, newdata = NULL, ...) {
 ```
 
 Some other things to keep in mind while writing `augment()` methods:
-* The `newdata` argument should default to `NULL`. Users should only ever specify one of `data` or `newdata`. Providing both `data` and `newdata` should result in an error. `newdata` should accept both `data.frame`s and `tibble`s.
+* The `newdata` argument should default to `NULL`. Users should only ever specify one of `data` or `newdata`. Providing both `data` and `newdata` should result in an error. The `newdata` argument should accept both `data.frame`s and `tibble`s.
 * Data given to the `data` argument must have both the original predictors and the original response. Data given to the `newdata` argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
 * If the `data` or `newdata` is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
 * For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
-* *`augment()` should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
+* *The `augment()` method should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
 
 {{% note %}} The recommended interface and functionality for `augment()` methods may change soon. {{%/ note %}}
 
 ## Document the new tidiers
 
-The only remaining step is to integrate the new tidiers into the parent package! To do so, just drop the tidiers into a `.R` file inside of the $/R$ folder and document them using roxygen2. If you're unfamiliar with the process of documenting objects, you can read more about it [here](http://r-pkgs.had.co.nz/man.html). Here's an example of how our `tidy.lm()` method might be documented:
+The only remaining step is to integrate the new tidiers into the parent package! To do so, just drop the tidiers into a `.R` file inside of the `/R` folder and document them using roxygen2. If you're unfamiliar with the process of documenting objects, you can read more about it [here](http://r-pkgs.had.co.nz/man.html). Here's an example of how our `tidy.lm()` method might be documented:
 
 ```{r, eval = FALSE}
 #' Tidy a(n) lm object
@@ -312,7 +312,7 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   # ... the rest of the function definition goes here!
 ```
 
-Once you've documented each of your new tidiers and ran `devtools::document()`, you're done! Congrats on implementing your own broom tidiers for a new model object!
+Once you've documented each of your new tidiers and executed `devtools::document()`, you're done! Congrats on implementing your own broom tidiers for a new model object!
 
 ## Glossaries: Argument and Column Names {#glossary}
 

--- a/content/learn/develop/broom/index.Rmarkdown
+++ b/content/learn/develop/broom/index.Rmarkdown
@@ -223,9 +223,9 @@ Some things to keep in mind while writing `glance()` methods:
 
 ### Implementing the `augment()` Tidier
 
-`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
+`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a data argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as data. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
 
-If a `data` argument is not specified, `augment()` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
+If a data argument is not specified, `augment()` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
 
 With this is mind, we can look back to our `trees_model` example. For one, the `model` element inside of the `trees_model` object will allow us to recover the original data:
 
@@ -270,11 +270,11 @@ augment.lm <- function(x, data = x$model, newdata = NULL, ...) {
 ```
 
 Some other things to keep in mind while writing `augment()` methods:
-* The `newdata` argument should default to `NULL`. Users should only ever specify one of `data` or `newdata`. Providing both `data` and `newdata` should result in an error. The `newdata` argument should accept both `data.frame`s and `tibble`s.
-* Data given to the `data` argument must have both the original predictors and the original response. Data given to the `newdata` argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
-* If the `data` or `newdata` is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
+* The newdata argument should default to `NULL`. Users should only ever specify one of data or newdata. Providing both data and newdata should result in an error. The newdata argument should accept both `data.frame`s and `tibble`s.
+* Data given to the data argument must have both the original predictors and the original response. Data given to the newdata argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
+* If the data or newdata is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
 * For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
-* *The `augment()` method should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
+* *The `augment()` method should always return as many rows as were in data or newdata*, depending on which is supplied
 
 {{% note %}} The recommended interface and functionality for `augment()` methods may change soon. {{%/ note %}}
 

--- a/content/learn/develop/broom/index.Rmarkdown
+++ b/content/learn/develop/broom/index.Rmarkdown
@@ -15,8 +15,7 @@ source(here::here("content/learn/common.R"))
 ```{r load, include = FALSE, message = FALSE, warning = FALSE}
 library(tidymodels)
 library(generics)
-
-pkgs <- c("tidymodels", "generics")
+pkgs <- c("tidymodels", "tidyverse", "generics", "usethis")
 ```
 
 ## Introduction

--- a/content/learn/develop/broom/index.markdown
+++ b/content/learn/develop/broom/index.markdown
@@ -272,9 +272,9 @@ Some things to keep in mind while writing `glance()` methods:
 
 ### Implementing the `augment()` Tidier
 
-`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a data argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as data. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
+`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata` argument, following the same conventions as the `data` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata` arguments need not contain the response columns in `data`. Only one of `data` or `newdata` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
 
-If a data argument is not specified, `augment()` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
+If a `data` argument is not specified, `augment()` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
 
 With this is mind, we can look back to our `trees_model` example. For one, the `model` element inside of the `trees_model` object will allow us to recover the original data:
 
@@ -360,11 +360,11 @@ augment.lm <- function(x, data = x$model, newdata = NULL, ...) {
 ```
 
 Some other things to keep in mind while writing `augment()` methods:
-* The newdata argument should default to `NULL`. Users should only ever specify one of data or newdata. Providing both data and newdata should result in an error. The newdata argument should accept both `data.frame`s and `tibble`s.
-* Data given to the data argument must have both the original predictors and the original response. Data given to the newdata argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
-* If the data or newdata is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
+* The `newdata` argument should default to `NULL`. Users should only ever specify one of `data` or `newdata`. Providing both `data` and `newdata` should result in an error. The `newdata` argument should accept both `data.frame`s and `tibble`s.
+* Data given to the `data` argument must have both the original predictors and the original response. Data given to the `newdata` argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
+* If the `data` or `newdata` is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
 * For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
-* *The `augment()` method should always return as many rows as were in data or newdata*, depending on which is supplied
+* *The `augment()` method should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
 
 {{% note %}} The recommended interface and functionality for `augment()` methods may change soon. {{%/ note %}}
 

--- a/content/learn/develop/broom/index.markdown
+++ b/content/learn/develop/broom/index.markdown
@@ -54,7 +54,7 @@ generics::glance
 
 Oftentimes it doesn't make sense to define one or more of these methods for a particular model. In this case, just implement the methods that do make sense.
 
-Note: please do not define `tidy()`, `glance()` or `augment()` generics in your package. This will result in namespace conflicts whenever your package is used along other packages that also export tidying methods.
+{{% warning %}} Please do not define `tidy()`, `glance()` or `augment()` generics in your package. This will result in namespace conflicts whenever your package is used along other packages that also export tidying methods. {{%/ warning %}}
 
 ## Implement Tidying Methods
 
@@ -146,7 +146,7 @@ colnames(trees_model_tidy) <- c("term", "estimate", "std.error", "statistic", "p
 
 A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [at the end of this article](#glossary)). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
 
-Finally, it is common for `tidy()` methods to include an option to calculate confidence/credible interval for each component based on the model, when possible. In this case, the `confint()` function can be used to calculate confidence intervals from a model object resulting from `lm()`:
+Finally, it is common for `tidy()` methods to include an option to calculate confidence/credible intervals for each component based on the model, when possible. In this example, the `confint()` function can be used to calculate confidence intervals from a model object resulting from `lm()`:
 
 
 ```r
@@ -178,6 +178,8 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   result
 }
 ```
+
+{{% note %}}  If you're interested, the actual `tidy.lm()` source can be found [here](https://github.com/tidymodels/broom/blob/master/R/stats-lm-tidiers.R)! It's not too different from the version above except for some argument checking and additional columns. {{%/ note %}}
 
 With this method exported, then, if a user called `tidy(fit)`, where `fit` was an output from `lm()`, the `tidy()` generic would "redirect" the call to the `tidy.lm()` function above.
 
@@ -261,7 +263,7 @@ glance.lm <- function(x, ...) {
 }
 ```
 
-In fact, this is the actual definition of `glance.lm()` provided by broom!
+{{% note %}} This is the actual definition of `glance.lm()` provided by broom! {{%/ note %}}
 
 Some things to keep in mind while writing `glance()` methods:
 * Output should not include the name of the modeling function or any arguments given to the modelling function.
@@ -312,7 +314,6 @@ trees_model$model
 #> 30   51.0  18.0     80
 #> 31   77.0  20.6     87
 ```
-
 
 Similarly, the fitted values and residuals can be accessed with the following code:
 
@@ -365,7 +366,7 @@ Some other things to keep in mind while writing `augment()` methods:
 * For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
 * *`augment()` should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
 
-Please note that the recommended interface and functionality for `augment()` methods may change soon.
+{{% note %}} The recommended interface and functionality for `augment()` methods may change soon. {{%/ note %}}
 
 ## Document the new tidiers
 

--- a/content/learn/develop/broom/index.markdown
+++ b/content/learn/develop/broom/index.markdown
@@ -14,7 +14,7 @@ description: |
 
 ## Introduction
 
-To use the code in this article, you will need to install the following packages: generics and tidymodels.
+To use the code in this article, you will need to install the following packages: generics, tidymodels, tidyverse, and usethis.
 
 The broom package provides tools to summarize key information about models in tidy `tibble()`s. The package provides three verbs, or "tidiers," to help make model objects easier to work with:
 
@@ -418,23 +418,23 @@ Once you've documented each of your new tidiers and ran `devtools::document()`, 
 #>  date     2020-05-21                  
 #> 
 #> ─ Packages ───────────────────────────────────────────────────────────────────
-#>  package    * version    date       lib source                            
-#>  broom      * 0.5.5      2020-02-29 [1] CRAN (R 3.6.1)                    
-#>  dials      * 0.0.4      2019-12-02 [1] CRAN (R 3.6.1)                    
-#>  dplyr      * 0.8.5      2020-03-07 [1] CRAN (R 3.6.0)                    
-#>  generics   * 0.0.2      2018-11-29 [1] CRAN (R 3.6.0)                    
-#>  ggplot2    * 3.3.0.9000 2020-04-28 [1] Github (tidyverse/ggplot2@296eecb)
-#>  infer      * 0.5.1.9000 2020-05-11 [1] local                             
-#>  parsnip    * 0.0.5      2020-01-07 [1] CRAN (R 3.6.1)                    
-#>  purrr      * 0.3.4      2020-04-17 [1] CRAN (R 3.6.1)                    
-#>  recipes    * 0.1.10     2020-03-18 [1] CRAN (R 3.6.1)                    
-#>  rlang        0.4.5.9000 2020-04-17 [1] Github (r-lib/rlang@a90b04b)      
-#>  rsample    * 0.0.5      2019-07-12 [1] CRAN (R 3.6.1)                    
-#>  tibble     * 3.0.1      2020-04-20 [1] CRAN (R 3.6.2)                    
-#>  tidymodels * 0.1.0      2020-02-16 [1] CRAN (R 3.6.1)                    
-#>  tune       * 0.0.1      2020-02-11 [1] CRAN (R 3.6.1)                    
-#>  workflows  * 0.1.1      2020-03-17 [1] CRAN (R 3.6.1)                    
-#>  yardstick  * 0.0.6      2020-03-17 [1] CRAN (R 3.6.1)                    
+#>  package    * version date       lib source        
+#>  broom      * 0.5.6   2020-04-20 [1] CRAN (R 3.6.2)
+#>  dials      * 0.0.4   2019-12-02 [1] CRAN (R 3.6.1)
+#>  dplyr      * 0.8.5   2020-03-07 [1] CRAN (R 3.6.0)
+#>  generics   * 0.0.2   2018-11-29 [1] CRAN (R 3.6.0)
+#>  ggplot2    * 3.3.0   2020-03-05 [1] CRAN (R 3.6.0)
+#>  infer      * 0.5.1   2019-11-19 [1] CRAN (R 3.6.0)
+#>  parsnip    * 0.0.5   2020-01-07 [1] CRAN (R 3.6.1)
+#>  purrr      * 0.3.4   2020-04-17 [1] CRAN (R 3.6.1)
+#>  recipes    * 0.1.10  2020-03-18 [1] CRAN (R 3.6.1)
+#>  rlang        0.4.6   2020-05-02 [1] CRAN (R 3.6.2)
+#>  rsample    * 0.0.5   2019-07-12 [1] CRAN (R 3.6.1)
+#>  tibble     * 3.0.1   2020-04-20 [1] CRAN (R 3.6.2)
+#>  tidymodels * 0.1.0   2020-02-16 [1] CRAN (R 3.6.0)
+#>  tune       * 0.0.1   2020-02-11 [1] CRAN (R 3.6.1)
+#>  workflows  * 0.1.1   2020-03-17 [1] CRAN (R 3.6.1)
+#>  yardstick  * 0.0.6   2020-03-17 [1] CRAN (R 3.6.1)
 #> 
 #> [1] /Users/simonpcouch/Library/R/3.6/library
 #> [2] /Library/Frameworks/R.framework/Versions/3.6/Resources/library

--- a/content/learn/develop/broom/index.markdown
+++ b/content/learn/develop/broom/index.markdown
@@ -34,9 +34,9 @@ In this article, we'll walk through each of the above steps in detail, giving ex
 
 ## Re-export the Tidier Generics
 
-The first step is to re-export the generic functions for `tidy()`, `glance()`, and/or `augment()`. You could do so from `broom` itself, but we've provided an alternative, much lighter dependency called `modelgenerics`.
+The first step is to re-export the generic functions for `tidy()`, `glance()`, and/or `augment()`. You could do so from `broom` itself, but we've provided an alternative, much lighter dependency called `generics`.
 
-First you'll need to add the [modelgenerics](https://github.com/tidymodels/modelgenerics) package to `Imports`. We recommend using the [usethis](https://github.com/r-lib/usethis) package for this:
+First you'll need to add the [generics](https://github.com/tidymodels/generics) package to `Imports`. We recommend using the [usethis](https://github.com/r-lib/usethis) package for this:
 
 
 ```r
@@ -108,7 +108,7 @@ This output gives some summary statistics on the residuals (which would be descr
 
 ### Implementing the `tidy()` Tidier
 
-The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [this dataframe](https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These methods are useful for inspecting model details and creating custom model visualizations.
+The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These methods are useful for inspecting model details and creating custom model visualizations.
 
 Returning to the example of our linear model on timber volume, we'd like to extract information on the model components. In this example, the components are the regression coefficients. After taking a look at the model object and its `summary()`, you might notice that you can extract the regression coefficients as follows:
 
@@ -144,7 +144,7 @@ broom standardizes common column names used to described coefficients. In this c
 colnames(trees_model_tidy) <- c("term", "estimate", "std.error", "statistic", "p.value")
 ```
 
-A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [here](https://github.com/alexpghayes/modeltests/blob/master/data/column_glossary.rda). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
+A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [at the end of this article](#glossary)). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
 
 Finally, it is common for `tidy()` methods to include an option to calculate confidence/credible interval for each component based on the model, when possible. In this case, the `confint()` function can be used to calculate confidence intervals from a model object resulting from `lm()`:
 
@@ -200,7 +200,7 @@ tidy(model, effects = "random")
 
 ### Implementing the `glance()` Tidier
 
-`glance()` returns a one-row tibble providing model-level summarizations (e.g. goodness of fitness measures and related statistics). This is useful to check for model misspecification and to compare many models. Again, the `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `glance()` methods can also take additional arguments and _must_ include the `x` and `...` arguments. (For a glossary of currently acceptable additional arguments, see [this dataframe](https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda).)
+`glance()` returns a one-row tibble providing model-level summarizations (e.g. goodness of fitness measures and related statistics). This is useful to check for model misspecification and to compare many models. Again, the `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `glance()` methods can also take additional arguments and _must_ include the `x` and `...` arguments. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)
 
 Returning to the `trees_model` example, we could pull out the `\(R^2\)` value with the following code:
 
@@ -270,7 +270,7 @@ Some things to keep in mind while writing `glance()` methods:
 
 ### Implementing the `augment()` Tidier
 
-`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given [here](https://github.com/alexpghayes/modeltests/blob/master/data/column_glossary.rda).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found [here](https://github.com/alexpghayes/modeltests/blob/master/data/argument_glossary.rda).
+`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
 
 If a `data` argument is not specified, `augment` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
 
@@ -363,6 +363,7 @@ Some other things to keep in mind while writing `augment()` methods:
 * Data given to the `data` argument must have both the original predictors and the original response. Data given to the `newdata` argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
 * If the `data` or `newdata` is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
 * For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
+* *`augment()` should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
 
 Please note that the recommended interface and functionality for `augment()` methods may change soon.
 
@@ -382,6 +383,8 @@ The only remaining step is to integrate the new tidiers into the parent package!
 #'   and less than 1. Defaults to 0.95, which corresponds to a 
 #'   95 percent confidence interval.
 #' @param ... Unused, included for generic consistency only.
+#' @return A tidy [tibble::tibble()] summarizing component-level
+#'   information about the model
 #'
 #' @examples
 #' # load the trees dataset
@@ -401,6 +404,1294 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
 
 Once you've documented each of your new tidiers and ran `devtools::document()`, you're done! Congrats on implementing your own broom tidiers for a new model object!
 
+## Glossaries: Argument and Column Names {#glossary}
+
+
+
+Tidier methods have a standardized set of acceptable argument and output column names. The currently acceptable argument names by tidier method are:
+
+<table class="table" style="width: auto !important; margin-left: auto; margin-right: auto;">
+ <thead>
+  <tr>
+   <th style="text-align:left;"> Method </th>
+   <th style="text-align:left;"> Argument </th>
+  </tr>
+ </thead>
+<tbody>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> alpha </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> boot_se </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> by_class </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> col.names </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> component </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> conf.int </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> conf.level </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> conf.method </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> conf.type </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> diagonal </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> droppars </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> effects </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> ess </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> estimate.method </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> exponentiate </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> fe </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> include_studies </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> instruments </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> intervals </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> matrix </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> measure </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> na.rm </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> object </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> par_type </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> parameters </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> parametric </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> pars </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> prob </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> region </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> return_zeros </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> rhat </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> robust </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> scales </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> se.type </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> strata </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> test </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> trim </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> upper </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> deviance </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> diagnostics </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> looic </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> mcmc </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> test </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> x </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> data </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> newdata </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> se_fit </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> type.predict </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> type.residuals </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> weights </td>
+  </tr>
+</tbody>
+</table>
+
+The currently acceptable column names by tidier method are:
+
+<table class="table" style="width: auto !important; margin-left: auto; margin-right: auto;">
+ <thead>
+  <tr>
+   <th style="text-align:left;"> Method </th>
+   <th style="text-align:left;"> Column </th>
+  </tr>
+ </thead>
+<tbody>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> acf </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> adj.p.value </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> alternative </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> atmean </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> autocorrelation </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> bias </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> ci.width </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> class </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> cluster </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> coef.type </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> column1 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> column2 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> comp </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> comparison </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> component </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> conf.high </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> conf.low </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> contrast </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> cumulative </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> cutoff </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> den.df </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> denominator </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> dev.ratio </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> df </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> distance </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> estimate </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> estimate1 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> estimate2 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> event </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> exp </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> expected </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> fpr </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> GCV </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> group </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> group1 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> group2 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> index </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> item1 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> item2 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> kendall_score </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> lag </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> lambda </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> lhs </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> mcmc.error </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> mean </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> meansq </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> method </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> n </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> N </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> n.censor </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> n.event </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> n.risk </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> num.df </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> nzero </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> obs </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> op </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> outcome </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> p </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> p.value </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> p.value.weakinst </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> parameter </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> PC </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> percent </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> power </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> proportion </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> pyears </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> response </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> rhs </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> robust.se </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> row </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> scale </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> series </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> size </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> state </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> statistic </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> statistic.weakinst </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> std.all </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> std.dev </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> std.error </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> std.lv </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> std.nox </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> std_estimate </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> step </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> strata </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> stratum </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> study </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> sumsq </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> tau </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> term </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> time </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> tpr </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> type </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> uniqueness </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> value </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> var_kendall_score </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> variable </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> variance </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> withinss </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> y.level </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> y.value </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> tidy </td>
+   <td style="text-align:left;"> z </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> adj.r.squared </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> agfi </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> AIC </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> AICc </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> alpha </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> alternative </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> autocorrelation </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> avg.silhouette.width </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> betweenss </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> BIC </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> cfi </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> chi.squared </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> chisq </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> cochran.qe </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> cochran.qm </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> conf.high </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> conf.low </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> converged </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> convergence </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> crit </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> cv.crit </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> den.df </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> deviance </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> df </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> df.null </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> df.residual </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> dw.original </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> dw.transformed </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> edf </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> estimator </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> events </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> finTol </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> function.count </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> G </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> g.squared </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> gamma </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> gradient.count </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> H </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> h.squared </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> hypvol </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> i.squared </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> independence </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> isConv </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> iter </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> iterations </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> kHKB </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> kLW </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> lambda </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> lambda.1se </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> lambda.min </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> lambdaGCV </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> logLik </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> max.cluster.size </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> max.hazard </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> max.time </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> maxit </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> MCMC.burnin </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> MCMC.interval </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> MCMC.samplesize </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> measure </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> median </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> method </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> min.harzard </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> min.time </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> missing_method </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> model </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> n </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> n.clusters </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> n.factors </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> n.max </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> n.start </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> nevent </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> nexcluded </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> ngroups </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> nobs </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> norig </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> npar </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> npasses </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> null.deviance </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> nulldev </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> num.df </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> number.interaction </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> offtable </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> p.value </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> p.value.cochran.qe </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> p.value.cochran.qm </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> p.value.original </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> p.value.Sargan </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> p.value.transformed </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> p.value.Wu.Hausman </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> parameter </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> pen.crit </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> power </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> power.reached </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> pseudo.r.squared </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> r.squared </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> records </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> residual.deviance </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> rho </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> rho2 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> rho20 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> rmean </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> rmean.std.error </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> rmsea </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> rmsea.conf.high </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> rscore </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> score </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> sigma </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> sigma2_j </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> spar </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> srmr </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> statistic </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> statistic.Sargan </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> statistic.Wu.Hausman </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> tau </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> tau.squared </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> tau.squared.se </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> theta </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> timepoints </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> tli </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> tot.withinss </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> total </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> total.variance </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> totss </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> value </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> glance </td>
+   <td style="text-align:left;"> within.r.squared </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .class </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .cluster </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .cochran.qe.loo </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .col.prop </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .conf.high </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .conf.low </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .cooksd </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .cov.ratio </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .cred.high </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .cred.low </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .dffits </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .expected </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .fitted </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .fitted_j_0 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .fitted_j_1 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .hat </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .moderator </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .moderator.level </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .observed </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .probability </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .prop </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .remainder </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .resid </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .resid_j_0 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .resid_j_1 </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .row.prop </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .rownames </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .se.fit </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .seasadj </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .seasonal </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .sigma </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .std.resid </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .tau </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .tau.squared.loo </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .trend </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .uncertainty </td>
+  </tr>
+  <tr>
+   <td style="text-align:left;"> augment </td>
+   <td style="text-align:left;"> .weight </td>
+  </tr>
+</tbody>
+</table>
+
+Please file an issue at [alexpghayes/modeltests](https://github.com/alexpghayes/modeltests) to request new arguments/columns to be added to the glossaries.
+
 ## Session information
 
 
@@ -415,7 +1706,7 @@ Once you've documented each of your new tidiers and ran `devtools::document()`, 
 #>  collate  en_US.UTF-8                 
 #>  ctype    en_US.UTF-8                 
 #>  tz       America/Los_Angeles         
-#>  date     2020-05-21                  
+#>  date     2020-05-22                  
 #> 
 #> ─ Packages ───────────────────────────────────────────────────────────────────
 #>  package    * version date       lib source        
@@ -432,6 +1723,7 @@ Once you've documented each of your new tidiers and ran `devtools::document()`, 
 #>  rsample    * 0.0.5   2019-07-12 [1] CRAN (R 3.6.1)
 #>  tibble     * 3.0.1   2020-04-20 [1] CRAN (R 3.6.2)
 #>  tidymodels * 0.1.0   2020-02-16 [1] CRAN (R 3.6.0)
+#>  tidyverse  * 1.3.0   2019-11-21 [1] CRAN (R 3.6.0)
 #>  tune       * 0.0.1   2020-02-11 [1] CRAN (R 3.6.1)
 #>  workflows  * 0.1.1   2020-03-17 [1] CRAN (R 3.6.1)
 #>  yardstick  * 0.0.6   2020-03-17 [1] CRAN (R 3.6.1)

--- a/content/learn/develop/broom/index.markdown
+++ b/content/learn/develop/broom/index.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Create your own broom tidiers"
+title: "Create your own broom tidier methods"
 tags: [broom]
 categories: []
 type: learn-subsection
@@ -22,13 +22,13 @@ The broom package provides tools to summarize key information about models in ti
 * `glance()` reports information about the entire model
 * `augment()` adds information about observations to a dataset
 
-Each of the three verbs above are _generic_, in that they do not define a procedure to tidy a given model object, but instead redirect to the relevant _method_ implemented to tidy a specific type of model object. The broom package provides tidier methods for model objects from over 100 modeling packages along with nearly all of the model objects in the stats package that comes with base R. However, for maintainability purposes, the broom package authors now ask that requests for new tidier methods be first directed to the parent package (i.e. the package that supplies the model object) rather than to broom. Tidiers will generally only be integrated into broom in the case that the requester has already asked the maintainers of the model-owning package to implement tidiers in the parent package.
+Each of the three verbs above are _generic_, in that they do not define a procedure to tidy a given model object, but instead redirect to the relevant _method_ implemented to tidy a specific type of model object. The broom package provides methods for model objects from over 100 modeling packages along with nearly all of the model objects in the stats package that comes with base R. However, for maintainability purposes, the broom package authors now ask that requests for new methods be first directed to the parent package (i.e. the package that supplies the model object) rather than to broom. New methods will generally only be integrated into broom in the case that the requester has already asked the maintainers of the model-owning package to implement tidier methods in the parent package.
 
 We'd like to make implementing external tidier methods as painless as possible. The general process for doing so is:
 
 * re-export the tidier generics
 * implement tidying methods
-* document the new tidiers
+* document the new methods
 
 In this article, we'll walk through each of the above steps in detail, giving examples and pointing out helpful functions when possible.
 
@@ -58,7 +58,7 @@ Oftentimes it doesn't make sense to define one or more of these methods for a pa
 
 ## Implement tidying methods
 
-You'll now need to implement specific tidying methods for each of the tidiers you've re-exported in the above step. For each of `tidy()`, `glance()`, and `augment()`, we'll walk through the big picture, an example, and helpful resources.
+You'll now need to implement specific tidying methods for each of the generics you've re-exported in the above step. For each of `tidy()`, `glance()`, and `augment()`, we'll walk through the big picture, an example, and helpful resources.
 
 In this article, we'll use the base R dataset `trees`, giving the tree girth (in inches), height (in feet), and volume (in cubic feet), to fit an example linear model using the base R `lm()` function. 
 
@@ -106,7 +106,7 @@ summary(trees_model)
 
 This output gives some summary statistics on the residuals (which would be described more fully in an `augment()` output), model coefficients (which, in this case, make up the `tidy()` output), and some model-level summarizations such as RSE, `\(R^2\)`, etc. (which make up the `glance()` output.)
 
-### Implementing the `tidy()` Tidier
+### Implementing the `tidy()` method
 
 The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the dots (`...`) are an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These `tidy()` methods are useful for inspecting model details and creating custom model visualizations.
 
@@ -200,7 +200,7 @@ tidy(model, effects = "random")
   - `conf.level`: The confidence level to use for the interval when `conf.int = TRUE`. Typically defaults to `.95`.
   - `exponentiate`: A logical indicating whether or not model terms should be presented on an exponential scale (typical for logistic regression).
 
-### Implementing the `glance()` Tidier
+### Implementing the `glance()` method
 
 `glance()` returns a one-row tibble providing model-level summarizations (e.g. goodness of fitness measures and related statistics). This is useful to check for model misspecification and to compare many models. Again, the `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `glance()` methods can also take additional arguments and _must_ include the `x` and `...` arguments. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)
 
@@ -270,7 +270,7 @@ Some things to keep in mind while writing `glance()` methods:
 * In some cases, you may wish to provide model-level diagnostics not returned by the original object. For example, the above `glance.lm()` calculates `AIC` and `BIC` from the model fit. If these are easy to compute, feel free to add them. However, tidier methods are generally not an appropriate place to implement complex or time consuming calculations.
 * The `glance` method should always return the same columns in the same order when given an object of a given model class. If a summary metric (such as `AIC`) is not defined in certain circumstances, use `NA`.
 
-### Implementing the `augment()` Tidier
+### Implementing the `augment()` method
 
 `augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata` argument, following the same conventions as the `data` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata` arguments need not contain the response columns in `data`. Only one of `data` or `newdata` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
 
@@ -368,9 +368,9 @@ Some other things to keep in mind while writing `augment()` methods:
 
 {{% note %}} The recommended interface and functionality for `augment()` methods may change soon. {{%/ note %}}
 
-## Document the new tidiers
+## Document the new methods
 
-The only remaining step is to integrate the new tidiers into the parent package! To do so, just drop the tidiers into a `.R` file inside of the `/R` folder and document them using roxygen2. If you're unfamiliar with the process of documenting objects, you can read more about it [here](http://r-pkgs.had.co.nz/man.html). Here's an example of how our `tidy.lm()` method might be documented:
+The only remaining step is to integrate the new methods into the parent package! To do so, just drop the methods into a `.R` file inside of the `/R` folder and document them using roxygen2. If you're unfamiliar with the process of documenting objects, you can read more about it [here](http://r-pkgs.had.co.nz/man.html). Here's an example of how our `tidy.lm()` method might be documented:
 
 
 ```r
@@ -403,7 +403,7 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   # ... the rest of the function definition goes here!
 ```
 
-Once you've documented each of your new tidiers and executed `devtools::document()`, you're done! Congrats on implementing your own broom tidiers for a new model object!
+Once you've documented each of your new methods and executed `devtools::document()`, you're done! Congrats on implementing your own broom tidier methods for a new model object!
 
 ## Glossaries: Argument and Column Names {#glossary}
 
@@ -1707,27 +1707,27 @@ Please file an issue at [alexpghayes/modeltests](https://github.com/alexpghayes/
 #>  collate  en_US.UTF-8                 
 #>  ctype    en_US.UTF-8                 
 #>  tz       America/Los_Angeles         
-#>  date     2020-05-25                  
+#>  date     2020-05-26                  
 #> 
 #> ─ Packages ───────────────────────────────────────────────────────────────────
-#>  package    * version     date       lib source                           
-#>  broom      * 0.7.0.9000  2020-05-25 [1] Github (tidymodels/broom@8fc5e57)
-#>  dials      * 0.0.4       2019-12-02 [1] CRAN (R 3.6.1)                   
-#>  dplyr      * 0.8.99.9003 2020-05-25 [1] Github (tidyverse/dplyr@735e6a2) 
-#>  generics   * 0.0.2       2018-11-29 [1] CRAN (R 3.6.0)                   
-#>  ggplot2    * 3.3.0       2020-03-05 [1] CRAN (R 3.6.0)                   
-#>  infer      * 0.5.1       2019-11-19 [1] CRAN (R 3.6.0)                   
-#>  parsnip    * 0.0.5       2020-01-07 [1] CRAN (R 3.6.1)                   
-#>  purrr      * 0.3.4       2020-04-17 [1] CRAN (R 3.6.1)                   
-#>  recipes    * 0.1.12      2020-05-01 [1] CRAN (R 3.6.2)                   
-#>  rlang        0.4.6       2020-05-02 [1] CRAN (R 3.6.2)                   
-#>  rsample    * 0.0.6       2020-03-31 [1] CRAN (R 3.6.2)                   
-#>  tibble     * 3.0.1       2020-04-20 [1] CRAN (R 3.6.2)                   
-#>  tidymodels * 0.1.0       2020-02-16 [1] CRAN (R 3.6.0)                   
-#>  tidyverse  * 1.3.0       2019-11-21 [1] CRAN (R 3.6.0)                   
-#>  tune       * 0.0.1       2020-02-11 [1] CRAN (R 3.6.1)                   
-#>  workflows  * 0.1.1       2020-03-17 [1] CRAN (R 3.6.1)                   
-#>  yardstick  * 0.0.6       2020-03-17 [1] CRAN (R 3.6.1)                   
+#>  package    * version     date       lib source                            
+#>  broom      * 0.5.6       2020-04-20 [1] CRAN (R 3.6.2)                    
+#>  dials      * 0.0.4       2019-12-02 [1] CRAN (R 3.6.1)                    
+#>  dplyr      * 0.8.99.9003 2020-05-25 [1] Github (tidyverse/dplyr@735e6a2)  
+#>  generics   * 0.0.2       2018-11-29 [1] CRAN (R 3.6.0)                    
+#>  ggplot2    * 3.3.0.9000  2020-05-25 [1] Github (tidyverse/ggplot2@2b03e47)
+#>  infer      * 0.5.1.9000  2020-05-25 [1] local                             
+#>  parsnip    * 0.0.5       2020-01-07 [1] CRAN (R 3.6.1)                    
+#>  purrr      * 0.3.4       2020-04-17 [1] CRAN (R 3.6.1)                    
+#>  recipes    * 0.1.12      2020-05-01 [1] CRAN (R 3.6.2)                    
+#>  rlang        0.4.6       2020-05-02 [1] CRAN (R 3.6.2)                    
+#>  rsample    * 0.0.6       2020-03-31 [1] CRAN (R 3.6.2)                    
+#>  tibble     * 3.0.1       2020-04-20 [1] CRAN (R 3.6.2)                    
+#>  tidymodels * 0.1.0       2020-02-16 [1] CRAN (R 3.6.0)                    
+#>  tidyverse  * 1.3.0       2019-11-21 [1] CRAN (R 3.6.0)                    
+#>  tune       * 0.0.1       2020-02-11 [1] CRAN (R 3.6.1)                    
+#>  workflows  * 0.1.1       2020-03-17 [1] CRAN (R 3.6.1)                    
+#>  yardstick  * 0.0.6       2020-03-17 [1] CRAN (R 3.6.1)                    
 #> 
 #> [1] /Users/simonpcouch/Library/R/3.6/library
 #> [2] /Library/Frameworks/R.framework/Versions/3.6/Resources/library

--- a/content/learn/develop/broom/index.markdown
+++ b/content/learn/develop/broom/index.markdown
@@ -22,9 +22,9 @@ The broom package provides tools to summarize key information about models in ti
 * `glance()` reports information about the entire model
 * `augment()` adds information about observations to a dataset
 
-Each of the three verbs above are _generic_, in that they do not actually define a procedure to tidy a given model object, but instead redirect to the relevant _method_ implemented to tidy a specific type of model object. The package provides tidier methods for model objects from over 100 modeling packages and nearly all of the model objects in the stats package that comes with base R. However, for maintainability purposes, the broom package authors now ask that requests for new tidier methods be first directed to the parent package (i.e. the package that supplies the model object) rather than to broom. Tidiers will generally only be integrated into broom in the case that the requester has already asked the maintainers of the model-owning package to implement tidiers in the parent package.
+Each of the three verbs above are _generic_, in that they do not define a procedure to tidy a given model object, but instead redirect to the relevant _method_ implemented to tidy a specific type of model object. The broom package provides tidier methods for model objects from over 100 modeling packages along with nearly all of the model objects in the stats package that comes with base R. However, for maintainability purposes, the broom package authors now ask that requests for new tidier methods be first directed to the parent package (i.e. the package that supplies the model object) rather than to broom. Tidiers will generally only be integrated into broom in the case that the requester has already asked the maintainers of the model-owning package to implement tidiers in the parent package.
 
-As a result, we'd like to make implementing external tidier methods as painless as possible. The general process for doing so is as follows:
+We'd like to make implementing external tidier methods as painless as possible. The general process for doing so is:
 
 * re-export the tidier generics
 * implement tidying methods
@@ -32,7 +32,7 @@ As a result, we'd like to make implementing external tidier methods as painless 
 
 In this article, we'll walk through each of the above steps in detail, giving examples and pointing out helpful functions when possible.
 
-## Re-export the Tidier Generics
+## Re-export the tidier generics
 
 The first step is to re-export the generic functions for `tidy()`, `glance()`, and/or `augment()`. You could do so from `broom` itself, but we've provided an alternative, much lighter dependency called `generics`.
 
@@ -52,11 +52,11 @@ Next, you'll need to re-export the appropriate tidying methods. If you plan to i
 generics::glance
 ```
 
-Oftentimes it doesn't make sense to define one or more of these methods for a particular model. In this case, just implement the methods that do make sense.
+Oftentimes it doesn't make sense to define one or more of these methods for a particular model. In this case, only implement the methods that do make sense.
 
-{{% warning %}} Please do not define `tidy()`, `glance()` or `augment()` generics in your package. This will result in namespace conflicts whenever your package is used along other packages that also export tidying methods. {{%/ warning %}}
+{{% warning %}} Please do not define `tidy()`, `glance()`, or `augment()` generics in your package. This will result in namespace conflicts whenever your package is used along other packages that also export tidying methods. {{%/ warning %}}
 
-## Implement Tidying Methods
+## Implement tidying methods
 
 You'll now need to implement specific tidying methods for each of the tidiers you've re-exported in the above step. For each of `tidy()`, `glance()`, and `augment()`, we'll walk through the big picture, an example, and helpful resources.
 
@@ -104,11 +104,11 @@ summary(trees_model)
 #> F-statistic:  255 on 2 and 28 DF,  p-value: <2e-16
 ```
 
-This output gives some summary statistics on the residuals (which would be described more fully in an `augment()` output), model coefficients (which, in this case, make up the `tidy()` output, and some model-level summarizations such as RSE, `\(R^2\)`, etc. (which make up the `glance()` output.)
+This output gives some summary statistics on the residuals (which would be described more fully in an `augment()` output), model coefficients (which, in this case, make up the `tidy()` output), and some model-level summarizations such as RSE, `\(R^2\)`, etc. (which make up the `glance()` output.)
 
 ### Implementing the `tidy()` Tidier
 
-The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the `...` is an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These methods are useful for inspecting model details and creating custom model visualizations.
+The `tidy(x, ...)` method will return a tibble where each row contains information about a component of the model. The `x` input is a model object, and the dots (`...`) are an optional argument to supply additional information to any calls inside your method. New `tidy()` methods can take additional arguments, but _must_ include the `x` and `...` arguments to be compatible with the generic function. (For a glossary of currently acceptable additional arguments, see [the end of this article](#glossary).)  Examples of model components include regression coefficients (for regression models), clusters (for classification/clustering models), etc. These `tidy()` methods are useful for inspecting model details and creating custom model visualizations.
 
 Returning to the example of our linear model on timber volume, we'd like to extract information on the model components. In this example, the components are the regression coefficients. After taking a look at the model object and its `summary()`, you might notice that you can extract the regression coefficients as follows:
 
@@ -137,14 +137,14 @@ trees_model_tidy
 #> 3 Height         0.339        0.130      2.61   1.45e- 2
 ```
 
-broom standardizes common column names used to described coefficients. In this case, the column names are:
+The broom package standardizes common column names used to describe coefficients. In this case, the column names are:
 
 
 ```r
 colnames(trees_model_tidy) <- c("term", "estimate", "std.error", "statistic", "p.value")
 ```
 
-A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [at the end of this article](#glossary)). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
+A glossary giving the currently acceptable column names outputted by `tidy()` methods can be found [at the end of this article](#glossary). As a rule of thumb, column names resulting from `tidy()` methods should be all lowercase and contain only alphanumerics or periods (though there are plenty of exceptions).
 
 Finally, it is common for `tidy()` methods to include an option to calculate confidence/credible intervals for each component based on the model, when possible. In this example, the `confint()` function can be used to calculate confidence intervals from a model object resulting from `lm()`:
 
@@ -181,11 +181,11 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
 
 {{% note %}}  If you're interested, the actual `tidy.lm()` source can be found [here](https://github.com/tidymodels/broom/blob/master/R/stats-lm-tidiers.R)! It's not too different from the version above except for some argument checking and additional columns. {{%/ note %}}
 
-With this method exported, then, if a user called `tidy(fit)`, where `fit` was an output from `lm()`, the `tidy()` generic would "redirect" the call to the `tidy.lm()` function above.
+With this method exported, then, if a user calls `tidy(fit)`, where `fit` is an output from `lm()`, the `tidy()` generic would "redirect" the call to the `tidy.lm()` function above.
 
 Some things to keep in mind while writing your `tidy()` method:
 
-* Sometimes a model will have several different types of components. For example, in mixed models, there is different information associated with fixed effects and random effects, since this information doesn't have the same interpretation, it doesn't make sense to summarize the fixed and random effects in the same table. In cases like this you should add an argument that allows the user to specify which type of information they want. For example, you might implement an interface along the lines of:
+* Sometimes a model will have several different types of components. For example, in mixed models, there is different information associated with fixed effects and random effects. Since this information doesn't have the same interpretation, it doesn't make sense to summarize the fixed and random effects in the same table. In cases like this you should add an argument that allows the user to specify which type of information they want. For example, you might implement an interface along the lines of:
 
 
 ```r
@@ -266,15 +266,15 @@ glance.lm <- function(x, ...) {
 {{% note %}} This is the actual definition of `glance.lm()` provided by broom! {{%/ note %}}
 
 Some things to keep in mind while writing `glance()` methods:
-* Output should not include the name of the modeling function or any arguments given to the modelling function.
+* Output should not include the name of the modeling function or any arguments given to the modeling function.
 * In some cases, you may wish to provide model-level diagnostics not returned by the original object. For example, the above `glance.lm()` calculates `AIC` and `BIC` from the model fit. If these are easy to compute, feel free to add them. However, tidier methods are generally not an appropriate place to implement complex or time consuming calculations.
-* `glance` should always return the same columns in the same order when given an object of a given model class. If a summary metric (such as `AIC`) is not defined in certain circumstances, use `NA`.
+* The `glance` method should always return the same columns in the same order when given an object of a given model class. If a summary metric (such as `AIC`) is not defined in certain circumstances, use `NA`.
 
 ### Implementing the `augment()` Tidier
 
-`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a `data` argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as `data`. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
+`augment()` methods add columns to a dataset containing information such as fitted values, residuals or cluster assignments. All columns added to a dataset have a `.` prefix to prevent existing columns from being overwritten. (Currently acceptable column names are given in [the glossary](#glossary).) The `x` and `...` arguments share their meaning with the two functions described above. `augment` methods also optionally accept a data argument that is a `data.frame` (or `tibble`) to add observation-level information to, returning a `tibble` object with the same number of rows as data. Many `augment()` methods also accept a `newdata()` argument, following the same conventions as the `data()` argument, except with the underlying assumption that the model has not "seen" the data yet. As a result, `newdata()` arguments need not contain the response columns in `data()`. Only one of `data()` or `newdata()` should be supplied. A full glossary of acceptable arguments to `augment()` methods can be found at [the end of this article](#glossary).
 
-If a `data` argument is not specified, `augment` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
+If a data argument is not specified, `augment()` should try to reconstruct the original data as much as possible from the model object. This may not always be possible, and often it will not be possible to recover columns not used by the model.
 
 With this is mind, we can look back to our `trees_model` example. For one, the `model` element inside of the `trees_model` object will allow us to recover the original data:
 
@@ -360,17 +360,17 @@ augment.lm <- function(x, data = x$model, newdata = NULL, ...) {
 ```
 
 Some other things to keep in mind while writing `augment()` methods:
-* The `newdata` argument should default to `NULL`. Users should only ever specify one of `data` or `newdata`. Providing both `data` and `newdata` should result in an error. `newdata` should accept both `data.frame`s and `tibble`s.
-* Data given to the `data` argument must have both the original predictors and the original response. Data given to the `newdata` argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
-* If the `data` or `newdata` is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
+* The newdata argument should default to `NULL`. Users should only ever specify one of data or newdata. Providing both data and newdata should result in an error. The newdata argument should accept both `data.frame`s and `tibble`s.
+* Data given to the data argument must have both the original predictors and the original response. Data given to the newdata argument only needs to have the original predictors. This is important because there may be important information associated with training data that is not associated with test data. This means that the `original_data` object in `augment(model, data = original_data)` should provide `.fitted` and `.resid` columns (in most cases), whereas `test_data` in `augment(model, data = test_data)` only needs a `.fitted` column, even if the response is present in `test_data`.
+* If the data or newdata is specified as a `data.frame` with rownames, `augment` should return them in a column called `.rownames`.
 * For observations where no fitted values or summaries are available (where there's missing data, for example), return `NA`.
-* *`augment()` should always return as many rows as were in `data` or `newdata`*, depending on which is supplied
+* *The `augment()` method should always return as many rows as were in data or newdata*, depending on which is supplied
 
 {{% note %}} The recommended interface and functionality for `augment()` methods may change soon. {{%/ note %}}
 
 ## Document the new tidiers
 
-The only remaining step is to integrate the new tidiers into the parent package! To do so, just drop the tidiers into a `.R` file inside of the `\(/R\)` folder and document them using roxygen2. If you're unfamiliar with the process of documenting objects, you can read more about it [here](http://r-pkgs.had.co.nz/man.html). Here's an example of how our `tidy.lm()` method might be documented:
+The only remaining step is to integrate the new tidiers into the parent package! To do so, just drop the tidiers into a `.R` file inside of the `/R` folder and document them using roxygen2. If you're unfamiliar with the process of documenting objects, you can read more about it [here](http://r-pkgs.had.co.nz/man.html). Here's an example of how our `tidy.lm()` method might be documented:
 
 
 ```r
@@ -403,7 +403,7 @@ tidy.lm <- function(x, conf.int = FALSE, conf.level = 0.95, ...) {
   # ... the rest of the function definition goes here!
 ```
 
-Once you've documented each of your new tidiers and ran `devtools::document()`, you're done! Congrats on implementing your own broom tidiers for a new model object!
+Once you've documented each of your new tidiers and executed `devtools::document()`, you're done! Congrats on implementing your own broom tidiers for a new model object!
 
 ## Glossaries: Argument and Column Names {#glossary}
 
@@ -1707,27 +1707,27 @@ Please file an issue at [alexpghayes/modeltests](https://github.com/alexpghayes/
 #>  collate  en_US.UTF-8                 
 #>  ctype    en_US.UTF-8                 
 #>  tz       America/Los_Angeles         
-#>  date     2020-05-22                  
+#>  date     2020-05-25                  
 #> 
 #> ─ Packages ───────────────────────────────────────────────────────────────────
-#>  package    * version date       lib source        
-#>  broom      * 0.5.6   2020-04-20 [1] CRAN (R 3.6.2)
-#>  dials      * 0.0.4   2019-12-02 [1] CRAN (R 3.6.1)
-#>  dplyr      * 0.8.5   2020-03-07 [1] CRAN (R 3.6.0)
-#>  generics   * 0.0.2   2018-11-29 [1] CRAN (R 3.6.0)
-#>  ggplot2    * 3.3.0   2020-03-05 [1] CRAN (R 3.6.0)
-#>  infer      * 0.5.1   2019-11-19 [1] CRAN (R 3.6.0)
-#>  parsnip    * 0.0.5   2020-01-07 [1] CRAN (R 3.6.1)
-#>  purrr      * 0.3.4   2020-04-17 [1] CRAN (R 3.6.1)
-#>  recipes    * 0.1.10  2020-03-18 [1] CRAN (R 3.6.1)
-#>  rlang        0.4.6   2020-05-02 [1] CRAN (R 3.6.2)
-#>  rsample    * 0.0.5   2019-07-12 [1] CRAN (R 3.6.1)
-#>  tibble     * 3.0.1   2020-04-20 [1] CRAN (R 3.6.2)
-#>  tidymodels * 0.1.0   2020-02-16 [1] CRAN (R 3.6.0)
-#>  tidyverse  * 1.3.0   2019-11-21 [1] CRAN (R 3.6.0)
-#>  tune       * 0.0.1   2020-02-11 [1] CRAN (R 3.6.1)
-#>  workflows  * 0.1.1   2020-03-17 [1] CRAN (R 3.6.1)
-#>  yardstick  * 0.0.6   2020-03-17 [1] CRAN (R 3.6.1)
+#>  package    * version     date       lib source                           
+#>  broom      * 0.7.0.9000  2020-05-25 [1] Github (tidymodels/broom@8fc5e57)
+#>  dials      * 0.0.4       2019-12-02 [1] CRAN (R 3.6.1)                   
+#>  dplyr      * 0.8.99.9003 2020-05-25 [1] Github (tidyverse/dplyr@735e6a2) 
+#>  generics   * 0.0.2       2018-11-29 [1] CRAN (R 3.6.0)                   
+#>  ggplot2    * 3.3.0       2020-03-05 [1] CRAN (R 3.6.0)                   
+#>  infer      * 0.5.1       2019-11-19 [1] CRAN (R 3.6.0)                   
+#>  parsnip    * 0.0.5       2020-01-07 [1] CRAN (R 3.6.1)                   
+#>  purrr      * 0.3.4       2020-04-17 [1] CRAN (R 3.6.1)                   
+#>  recipes    * 0.1.12      2020-05-01 [1] CRAN (R 3.6.2)                   
+#>  rlang        0.4.6       2020-05-02 [1] CRAN (R 3.6.2)                   
+#>  rsample    * 0.0.6       2020-03-31 [1] CRAN (R 3.6.2)                   
+#>  tibble     * 3.0.1       2020-04-20 [1] CRAN (R 3.6.2)                   
+#>  tidymodels * 0.1.0       2020-02-16 [1] CRAN (R 3.6.0)                   
+#>  tidyverse  * 1.3.0       2019-11-21 [1] CRAN (R 3.6.0)                   
+#>  tune       * 0.0.1       2020-02-11 [1] CRAN (R 3.6.1)                   
+#>  workflows  * 0.1.1       2020-03-17 [1] CRAN (R 3.6.1)                   
+#>  yardstick  * 0.0.6       2020-03-17 [1] CRAN (R 3.6.1)                   
 #> 
 #> [1] /Users/simonpcouch/Library/R/3.6/library
 #> [2] /Library/Frameworks/R.framework/Versions/3.6/Resources/library


### PR DESCRIPTION
Hi! This is a draft of an article detailing how to write `tidy()`, `glance()`, and `augment()` methods for new model objects and integrate them into the packages that export the model objects. The thought is to point folks to this when issues/PRs are filed on the broom repo to add new tidiers since, generally(?), new tidiers won’t be added to broom.

Sorry if I’ve dropped this article in the wrong directory/if any of the article metadata is weird—still getting the hang of blogdown and the website’s organization.🙂

Some other things I was thinking about while writing this up...
* The `alexpghayes/modeltests` package has unit tests for new tidiers. The tests for `augment()` methods, though, (I think) reflect a rewrite of the function that hasn’t happened yet. Is it worth linking to the tests now, or waiting until I can get to the `augment()` rewrite to write a section about writing unit tests?
* I'm not sure on how much to say about what-to-do-with/where-to-put the code once it's written. I’ve dropped an example of roxygen2 documentation and a note about dropping code in a file in the `/R` folder at the end, but maybe it’s worth writing up a quick package to demo how these tidiers would be integrated into a package. Glad to do this if it would be helpful!