### PR TITLE
Refine shortcode CSS for tip boxes

### DIFF
--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -979,7 +979,7 @@ div.warning {
   color: #1a162dcc;
   background-color: #eab0c41a;
   border-top: 7pt solid #a19ea936;
-  max-width: 80%;
+  max-width: 100%;
   line-height: 1.75em;
   font-size: 0.85em;
   letter-spacing: 1pt;

--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -974,7 +974,7 @@ div.warning {
   padding-left: 100px;
   background-size: 70px;
   background-repeat: no-repeat;
-  background-position: 15px 1em;
+  background-position: 15px 1.5em;
   min-height: 120px;
   color: #1a162dcc;
   background-color: #eab0c41a;

--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -211,6 +211,10 @@ h4 {
 #TableOfContents ul li {
   padding-left: 0.5em; /* Wraps li when headers are too long */
   text-indent: -0.5em;
+  
+  /* Make spacing BETWEEN list items greater than wrapped lines WITHIN list items */
+  padding-bottom: 1.2em;
+  line-height: 1.2rem;
 }
 
 

--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -977,7 +977,7 @@ div.warning {
   background-position: 15px 1.5em;
   min-height: 120px;
   color: #1a162dcc;
-  background-color: #eab0c41a;
+  background-color: #91CBD738;
   border-top: 7pt solid #a19ea936;
   max-width: 100%;
   line-height: 1.75em;
@@ -995,17 +995,17 @@ div.rstudio-tip {
 
 div.warning {
   background-image: url("../images/error.png");
-  background-color: #d7611a1a !important;
+  background-color: #eab0c41a !important;
 }
 
 div.note code, 
 div.rstudio-tip code {
-  background-color: #cb9faf52 !important;
+  background-color: #91CBD765 !important;
   font-size: 1em;
 }
 
 div.warning code {
-  background-color: #ead3c3bd !important;
+  background-color: #cb9faf52 !important;
   font-size: 1em;
 }
 

--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -974,7 +974,7 @@ div.warning {
   padding-left: 100px;
   background-size: 70px;
   background-repeat: no-repeat;
-  background-position: 15px center;
+  background-position: 15px 1em;
   min-height: 120px;
   color: #1a162dcc;
   background-color: #eab0c41a;

--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -995,12 +995,17 @@ div.rstudio-tip {
 
 div.warning {
   background-image: url("../images/error.png");
+  background-color: #d7611a1a !important;
 }
 
 div.note code, 
-div.rstudio-tip code, 
-div.warning code {
+div.rstudio-tip code {
   background-color: #cb9faf52 !important;
+  font-size: 1em;
+}
+
+div.warning code {
+  background-color: #ead3c3bd !important;
   font-size: 1em;
 }
 

--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -189,35 +189,9 @@ h4 {
     color: #ca225ec9;
   }
 
-/*Getting Started TOC divider -- styling may change */
-
-/*
-#TOC{
-    padding: 2em;
-    position: relative;
-}
-#TOC:after,
-#TOC:before {
-    border: 1pt solid #ca225e3d; 
-    bottom: 0;    
-    content: '';
-    position: absolute;
-    top: 0;
-    width: 5%;
-}
-#TOC:after {
-    border-left: none;
-    right: 0;
-}
-#TOC:before {
-    border-right: none;
-    left: 0;
-}
-
-*/
-
 
 /*Sidebar TOC links for Learn and Packages pages */
+
 #TableOfContents a, 
 .articleCategory a {
   font-family: 'Lato', sans-serif;
@@ -231,8 +205,14 @@ h4 {
 .articleCategory a:hover {
   color: #1a162dde;
   text-decoration: none;
-
 }
+
+
+#TableOfContents ul li {
+  padding-left: 0.5em; /* Wraps li when headers are too long */
+  text-indent: -0.5em;
+}
+
 
 /*-- Getting Started Page Left Sidebar -- */
 


### PR DESCRIPTION
@apreshill let me know if these changes look okay to you

Warning box in this section: https://deploy-preview-166--tidymodels-org.netlify.app/learn/develop/models/#add-parsnip-models-to-another-package

And regular tip box: https://deploy-preview-166--tidymodels-org.netlify.app/start/models/#new-engine

__

Unrelated to shortcodes, but I also fix TOC readability for headers that wrapped

<img src="https://user-images.githubusercontent.com/29008894/82741190-c0a6f100-9d1d-11ea-965e-8c7668eeb674.png" width="40%">
