### PR TITLE
CSS fix for DT headers being too big

### DIFF
--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -373,10 +373,14 @@ table thead tr th:last-child {
     padding: 15px 13px;
 }
 
-.selectize-dropdown {
-    font-size: 0.75em;
-    text-transform: none;
+
+.selectize-dropdown, 
+.selectize-input.items.not-full.has-options.has-items {
+    font-size: 0.8rem !important;
+    text-transform: none !important;
 }
+
+
 
 /* MISC */
 /* This is to specifically target the package tag links within GEtting Started.*/

--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -373,6 +373,11 @@ table thead tr th:last-child {
     padding: 15px 13px;
 }
 
+.selectize-dropdown {
+    font-size: 0.75em;
+    text-transform: none;
+}
+
 /* MISC */
 /* This is to specifically target the package tag links within GEtting Started.*/
 /* This is a pretty brittle style rule and should probably get replaced */


### PR DESCRIPTION
This may not be as good of a solution as getting the DT column widths to change (#168), but perhaps this can fix it in the meantime