### PR TITLE
set the local hugo version to that on netflify

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,29 @@
+# REMEMBER to restart R after you modify and save this file!
+
+# First, execute the global .Rprofile if it exists. You may configure blogdown
+# options there, too, so they apply to any blogdown projects. Feel free to
+# ignore this part if it sounds too complicated to you.
+if (file.exists("~/.Rprofile")) {
+  base::sys.source("~/.Rprofile", envir = environment())
+}
+
+# Now set options to customize the behavior of blogdown for this project. Below
+# are a few sample options; for more options, see
+# https://bookdown.org/yihui/blogdown/global-options.html
+options(
+  # to automatically serve the site on RStudio startup, set this option to TRUE
+  blogdown.serve_site.startup = FALSE,
+  # to disable knitting Rmd files on save, set this option to FALSE
+  blogdown.knit.on_save = FALSE,
+  # build .Rmd to .html (via Pandoc); to build to Markdown, set this option to 'markdown'
+  blogdown.method = 'markdown'
+)
+
+library(magrittr)
+hugo_version <- readLines("netlify.toml") %>% 
+  stringr::str_subset("HUGO_VERSION") %>% 
+  stringr::str_extract("[0-9]+\\.*[0-9]*\\.*[0-9]*") %>% 
+  unique()
+
+# fix Hugo version
+options(blogdown.hugo.version = hugo_version)


### PR DESCRIPTION
Currently the README tells people to check their hugo version against the [version](https://github.com/tidymodels/tidymodels.org/blob/master/netlify.toml#L6) used on netlify and upgrade if necessary. 

However, people may need a particular (different) version for their own project. So I've added a project-specific `.Rprofile` which sets the version of hugo to be used for this project to the netlify version. 

If people then check their version with `blogdown::hugo_version()` as suggested in the README, they should receive an error if they don't have the right version installed. The error message also includes instructions on how to install the version needed here. 