### PR TITLE
Add dplyr to required packages

### DIFF
--- a/content/start/models/index.Rmarkdown
+++ b/content/start/models/index.Rmarkdown
@@ -38,6 +38,7 @@ library(tidymodels)  # for the parsnip package, along with the rest of tidymodel
 library(readr)       # for importing data
 library(broom.mixed) # for converting bayesian models to tidy tibbles
 library(dotwhisker)  # for visualizing regression results
+library(dplyr)       # for data manipulation
 ```
 
 


### PR DESCRIPTION
The code with the `urchins` data uses dplyr for its `mutate` function. Since `dplyr` isn't loaded, this, the code from the tutorial fails at this step.