### PR TITLE
Use `extract_parameter_set_dials()` instead of `parameters()`

### DIFF
--- a/content/learn/work/bayes-opt/index.Rmarkdown
+++ b/content/learn/work/bayes-opt/index.Rmarkdown
@@ -98,7 +98,7 @@ svm_wflow <-
 From this object, we can derive information about what parameters are slated to be tuned. A parameter set is derived by: 
 
 ```{r pset}
-svm_set <- parameters(svm_wflow)
+svm_set <- extract_parameter_set_dials(svm_wflow)
 svm_set
 ```
 

--- a/content/learn/work/tune-text/index.Rmarkdown
+++ b/content/learn/work/tune-text/index.Rmarkdown
@@ -256,7 +256,7 @@ Then we can extract and manipulate the corresponding parameter set:
 ```{r search-set}
 five_star_set <-
   five_star_wflow %>%
-  parameters() %>%
+  extract_parameter_set_dials() %>%
   update(
     num_terms = hash_range, 
     penalty = penalty(c(-3, 0)),

--- a/content/start/case-study/index.Rmarkdown
+++ b/content/start/case-study/index.Rmarkdown
@@ -353,7 +353,7 @@ rf_mod
 
 # show what will be tuned
 rf_mod %>%    
-  parameters()  
+  extract_parameter_set_dials()  
 ```
 
 The `mtry` hyperparameter sets the number of predictor variables that each node in the decision tree "sees" and can learn about, so it can range from 1 to the total number of features present; when `mtry` = all possible features, the model is the same as bagging decision trees. The `min_n` hyperparameter sets the minimum `n` to split at any node.


### PR DESCRIPTION
This PR is prep for when the deprecation of the `parameters()` methods for recipes, model specs, and work flows in tune goes to CRAN.

Note, it's still missing the rendered files.