### PR TITLE
Change "purrr" to "tidyr" for `unnest`

### DIFF
--- a/content/learn/models/coefficients/index.Rmarkdown
+++ b/content/learn/models/coefficients/index.Rmarkdown
@@ -124,7 +124,7 @@ There is _another_ column in this element called `.extracts` that has the result
 lm_res$.extracts[[1]]$.extracts[[1]]
 ```
 
-These nested columns can be flattened via the purrr `unnest()` function: 
+These nested columns can be flattened via the tidyr `unnest()` function: 
 
 ```{r lm-extract-almost}
 lm_res %>% 

--- a/content/learn/models/coefficients/index.markdown
+++ b/content/learn/models/coefficients/index.markdown
@@ -164,7 +164,7 @@ lm_res$.extracts[[1]]$.extracts[[1]]
 #> 4 Harlem        -0.637    0.163      -3.92 9.01e-  5
 ```
 
-These nested columns can be flattened via the purrr `unnest()` function: 
+These nested columns can be flattened via the tidyr `unnest()` function: 
 
 
 ```r
@@ -578,33 +578,33 @@ Notice a couple of things:
 #> ─ Session info ─────────────────────────────────────────────────────
 #>  setting  value
 #>  version  R version 4.1.2 (2021-11-01)
-#>  os       macOS Monterey 12.3
+#>  os       macOS Monterey 12.3.1
 #>  system   aarch64, darwin20
 #>  ui       X11
 #>  language (EN)
-#>  collate  en_GB.UTF-8
-#>  ctype    en_GB.UTF-8
-#>  tz       Europe/London
-#>  date     2022-04-11
-#>  pandoc   2.14.0.3 @ /Applications/RStudio.app/Contents/MacOS/pandoc/ (via rmarkdown)
+#>  collate  en_US.UTF-8
+#>  ctype    en_US.UTF-8
+#>  tz       America/New_York
+#>  date     2022-06-20
+#>  pandoc   2.17.1.1 @ /Applications/RStudio.app/Contents/MacOS/quarto/bin/ (via rmarkdown)
 #> 
 #> ─ Packages ─────────────────────────────────────────────────────────
 #>  package    * version date (UTC) lib source
-#>  broom      * 0.7.12  2022-01-28 [1] CRAN (R 4.1.1)
-#>  dials      * 0.1.1   2022-04-06 [1] CRAN (R 4.1.2)
-#>  dplyr      * 1.0.8   2022-02-08 [1] CRAN (R 4.1.2)
-#>  ggplot2    * 3.3.5   2021-06-25 [1] CRAN (R 4.1.1)
-#>  glmnet     * 4.1-3   2021-11-02 [1] CRAN (R 4.1.2)
+#>  broom      * 0.8.0   2022-04-13 [1] CRAN (R 4.1.1)
+#>  dials      * 1.0.0   2022-06-14 [1] CRAN (R 4.1.2)
+#>  dplyr      * 1.0.9   2022-04-28 [1] CRAN (R 4.1.1)
+#>  ggplot2    * 3.3.6   2022-05-03 [1] CRAN (R 4.1.1)
+#>  glmnet     * 4.1-4   2022-04-15 [1] CRAN (R 4.1.1)
 #>  infer      * 1.0.0   2021-08-13 [1] CRAN (R 4.1.1)
-#>  parsnip    * 0.2.1   2022-03-17 [1] CRAN (R 4.1.1)
+#>  parsnip    * 1.0.0   2022-06-16 [1] CRAN (R 4.1.2)
 #>  purrr      * 0.3.4   2020-04-17 [1] CRAN (R 4.1.0)
 #>  recipes    * 0.2.0   2022-02-18 [1] CRAN (R 4.1.1)
-#>  rlang        1.0.2   2022-03-04 [1] CRAN (R 4.1.1)
+#>  rlang        1.0.2   2022-03-04 [1] CRAN (R 4.1.2)
 #>  rsample    * 0.1.1   2021-11-08 [1] CRAN (R 4.1.2)
-#>  tibble     * 3.1.6   2021-11-07 [1] CRAN (R 4.1.1)
-#>  tidymodels * 0.2.0   2022-03-19 [1] CRAN (R 4.1.1)
+#>  tibble     * 3.1.7   2022-05-03 [1] CRAN (R 4.1.1)
+#>  tidymodels * 0.2.0   2022-03-19 [1] CRAN (R 4.1.2)
 #>  tune       * 0.2.0   2022-03-19 [1] CRAN (R 4.1.2)
-#>  workflows  * 0.2.6   2022-03-18 [1] CRAN (R 4.1.2)
+#>  workflows  * 0.2.6   2022-03-18 [1] CRAN (R 4.1.1)
 #>  yardstick  * 0.0.9   2021-11-22 [1] CRAN (R 4.1.1)
 #> 
 #>  [1] /Library/Frameworks/R.framework/Versions/4.1-arm64/Resources/library


### PR DESCRIPTION
In [Working with model coefficients](https://www.tidymodels.org/learn/models/coefficients/), a line of text attributes `unnest` to `purrr` even though it is exported from `tidyr`.